### PR TITLE
v2.0.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.0.3
+- FEATURE: Allow multiple statuses in the sr_listings short-code.
+- BUGFIX: Fix image rendering when image URL contains forward slashes.
+
+## 2.0.2
+* BUGFIX: Fix sr_ptypes query parameter when using multiple property types.
+
+## 2.0.1
+* BUGFIX: Fix sr_listings_slider links to listing details
+
+## 2.0.0
+* FEATURE: Support for pretty permalinks!
+* FEATURE: Pretty permalink options in the admin panel
+* IMPROVEMENT: URL's not longer contain the listing's price, so they
+  are much more easily shareable on social media.
+* BUGS: Misc, minor bugs and code cleanup.
+
+## 1.7.2
+* FEATURE: Adds the ability to configure sr_search_form to search
+  specified property type(s) via short-code attributes.
+
 ## 1.7.1
 * BUG FIX: Fix population of property-types dropdown on the
   sr_map_search search form
@@ -139,7 +160,7 @@
 * New Image Gallery Option! With full screen and thumbnails
 * Add option to show/hide listing description (remarks)
 * Better handling of fields that may or may not be present
-* other fixes and improvements 
+* other fixes and improvements
 
 ## 1.2.0
 * Add graphical shortcode/page builder got creating listing shortcodes
@@ -147,7 +168,7 @@
 * Add support for agent ID query parameter in shortcode & custom post type
 * Add more styling and clean up text in admin settings panel
 * better error handling
-* other fixes and improvements 
+* other fixes and improvements
 
 ## 1.1.5
 * Automatically save test credentials when plugin is activated to make it easier to get started.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.4
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.0.3 =
+* BUGFIX: Fix image rendering when image URL contains forward slashes.
 
 = 2.0.2 =
 * BUGFIX: Fix sr_ptypes query parameter when using multiple property types.

--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,7 @@ listing sidebar widget.
 == Changelog ==
 
 = 2.0.3 =
+* FEATURE: Allow multiple statuses in the sr_listings short-code.
 * BUGFIX: Fix image rendering when image URL contains forward slashes.
 
 = 2.0.2 =
@@ -454,8 +455,11 @@ Fetches a single listing by it's mlsid.
 `[sr_listings mlsid="12345"]`
 
 * **status**
-Refines listings by a certain status, like Active, Pending, or Closed.
+Refines listings by a certain status, like Active, Pending, or Closed. (Separate multiple with a semicolon ';')
 `[sr_listings status="Closed"]`
+`[sr_listings status="Active; Pending"]`
+
+*Note: By default, Active and Pending are queried*
 
 * **minprice**
 Refines listings to a minimum price.
@@ -522,7 +526,7 @@ Refines listings to a given set of features. (Separate multiple with a semi-colo
 `[sr_listings cities="Tennis Court; Waterfront"]`
 
 * **vendor**
-Refines listings by a certain vendor or MLS Board. (This is only available when your account has multiple MLS's).
+Refines listings by a certain vendor or MLS Board. (This is required when your account has multiple MLS's).
 `[sr_listings vendor="MFRMLS"]`
 
 * **limit**
@@ -539,6 +543,8 @@ Displays the listings in a specific order.
 
 (The available sort options are `listprice`, `-listprice`, `listdate`, `-listdate`, `baths`, `-baths`, `beds`, and `-beds`.
 Options starting the a minus (-) are high to low, no minus sign is low to high).
+
+*Note: By default, the listings are sorted by modification time, newest first*
 
 * **advanced**
 This attribute is to turn the basic search form into an advanced search form.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1304,6 +1304,7 @@ HTML;
                 $listingPhotos[0] = plugins_url( 'assets/img/defprop.jpg', __FILE__ );
             }
             $main_photo = $listingPhotos[0];
+            $main_photo = str_replace("\\", "", $main_photo);
 
             // create link to listing
             $link = SrUtils::buildDetailsLink(

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1108,6 +1108,7 @@ HTML;
                 $listingPhotos[0] = plugins_url( 'assets/img/defprop.jpg', __FILE__ );
             }
             $main_photo = trim($listingPhotos[0]);
+            $main_photo = str_replace("\\", "", $main_photo);
 
             // listing link to details
             $link = SrUtils::buildDetailsLink(

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.0.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.0.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.0.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.0.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -559,10 +559,15 @@ class SimplyRetsCustomPostPages {
              * to be made into an array. The others aren't like that,
              * so we should fix this one.
              */
+
+            /** Multiple Types */
             $p_types = isset($_GET['sr_ptype']) ? $_GET['sr_ptype'] : '';
+            $ptypes_string = '';
             if(!is_array($p_types)) {
                 if(strpos($p_types, ";") !== FALSE) {
                     $p_types = explode(';', $p_types);
+                } else {
+                    $ptypes_string = "&type=$p_types";
                 }
             }
             if(is_array($p_types) && !empty($p_types)) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -552,6 +552,13 @@ class SimplyRetsCustomPostPages {
                                           get_option('sr_search_map_position'));
 
 
+            /**
+             * Check if there is multiple 'types' being searched.
+             * HACK: This is a bit of hack because sometimes the parameters
+             * are in an array() and sometimes they are in a string that needs
+             * to be made into an array. The others aren't like that,
+             * so we should fix this one.
+             */
             $p_types = isset($_GET['sr_ptype']) ? $_GET['sr_ptype'] : '';
             if(!is_array($p_types)) {
                 if(strpos($p_types, ";") !== FALSE) {
@@ -564,6 +571,21 @@ class SimplyRetsCustomPostPages {
                     $ptypes_string .= "&type=$final";
                 }
             }
+
+            /**
+             * The loops below check if the short-code has multiple
+             * values for any query parameter. Eg, multiple cities.
+             * Since they support multiple, we do the following for
+             * each:
+             *
+             *
+             * - Split string on ';' delimeter (which returns a single
+                 item array if there is none)
+             *
+             * - Make each array item into a query (eg, &status=Closed)
+             *
+             * - Concat them together (eg,&status=Active&status=Closed)
+             */
 
             $features = isset($_GET['sr_features']) ? $_GET['sr_features'] : '';
             if(!empty($features)) {
@@ -599,7 +621,13 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
-            // these should correlate with what the api expects as filters
+            /**
+             * Make a new array with all query parameters.
+             *
+             * Note: We're only using params that weren't transformed
+             * above.
+             */
+
             $listing_params = array(
                 "q"         => $keywords,
                 "brokers"   => $brokers,
@@ -643,6 +671,9 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
+            /**
+             * Make advanced search page with new query
+             */
             if( !$advanced || !$advanced == "true" ) {
               $qs = '?'
                   . http_build_query( array_filter( $listing_params ) )
@@ -659,6 +690,9 @@ class SimplyRetsCustomPostPages {
               $content .= $listings_content;
               return $content;
 
+            /**
+             * Make regular search page with new query
+             */
             } else {
 
               $qs = '?';

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -572,6 +572,24 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
+
+            /** Multiple Statuses */
+            $statuses = isset($_GET['sr_status']) ? $_GET['sr_status'] : $status;
+            $statuses_string = '';
+            if(!is_array($statuses)) {
+                if(strpos($statuses, ";") !== FALSE) {
+                    $statuses = explode(';', $statuses);
+                } else {
+                    $statuses_string = "&status=$statuses";
+                }
+            }
+            if(is_array($statuses) && !empty($statuses)) {
+                foreach((array)$statuses as $key => $stat) {
+                    $final = trim($stat);
+                    $statuses_string .= "&status=$final";
+                }
+            }
+
             /**
              * The loops below check if the short-code has multiple
              * values for any query parameter. Eg, multiple cities.
@@ -646,7 +664,6 @@ class SimplyRetsCustomPostPages {
                 /** Advanced Search */
                 "lotsize"   => $lotsize,
                 "area"      => $area,
-                "status"    => $status,
                 "sort"      => $sort,
 
                 /** Multi MLS */
@@ -682,6 +699,7 @@ class SimplyRetsCustomPostPages {
                   . $neighborhoods_string
                   . $agents_string
                   . $ptypes_string
+                  . $statuses_string
                   . $amenities_string;
 
               $qs = str_replace(' ', '%20', $qs);
@@ -702,6 +720,7 @@ class SimplyRetsCustomPostPages {
               $qs .= $agents_string;
               $qs .= $ptypes_string;
               $qs .= $neighborhoods_string;
+              $qs .= $statuses_string;
               $qs .= $amenities_string;
 
               $qs = str_replace(' ', '%20', $qs);

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -171,6 +171,9 @@ HTML;
     public function sr_residential_shortcode( $atts ) {
         global $wp_query;
 
+        /**
+         * Check if `mlsId` was supplied. If so, just query that.
+         */
         if(!empty($atts['mlsid'])) {
             $qs = '/' . $atts['mlsid'];
             if(array_key_exists('vendor', $atts) && !empty($atts['vendor'])) {
@@ -186,6 +189,13 @@ HTML;
             $listing_params = $atts;
         }
 
+        /**
+         * The below parameters currently support multiple values via
+         * a semicolon delimeter. Eg, status="Active; Closed"
+         *
+         * Before we send them, build a proper query string that the API
+         * can understand. Eg, status=Active&status=Closed
+         */
         if( !isset($listing_params['neighborhoods'])
             && !isset($listing_params['postalcodes'])
             && !isset($listing_params['cities'])
@@ -236,9 +246,6 @@ HTML;
                 $ptypes_string = str_replace(' ', '%20', $ptypes_string );
             }
 
-            /**
-             * Postal Codes filter is being used - check for multiple values and build query accordingly
-             */
             if( isset( $listing_params['postalcodes'] ) && !empty( $listing_params['postalcodes'] ) ) {
                 $postalcodes = explode( ';', $listing_params['postalcodes'] );
                 foreach( $postalcodes as $key => $postalcode  ) {
@@ -248,7 +255,11 @@ HTML;
                 $postalcodes_string = str_replace(' ', '%20', $postalcodes_string );
             }
 
+            /**
+             * Build a regular query string for everything else
+             */
             foreach( $listing_params as $key => $value ) {
+                // Skip params that support multiple
                 if( $key !== 'postalcodes'
                     && $key !== 'neighborhoods'
                     && $key !== 'cities'
@@ -259,6 +270,9 @@ HTML;
                 }
             }
 
+            /**
+             * Final query string
+             */
             $qs = '?';
             $qs .= $neighborhoods_string;
             $qs .= $cities_string;

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -201,6 +201,7 @@ HTML;
             && !isset($listing_params['cities'])
             && !isset($listing_params['agent'])
             && !isset($listing_params['type'])
+            && !isset($listing_params['status'])
         )
         {
             $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $listing_params, $atts );
@@ -256,6 +257,21 @@ HTML;
             }
 
             /**
+             * Multiple statuses
+             */
+            if( isset( $listing_params['status'] ) && !empty( $listing_params['status'] ) ) {
+
+                $statuses = explode( ';', $listing_params['status'] );
+
+                foreach( $statuses as $key => $stat) {
+                    $stat = trim($stat);
+                    $statuses_string .= "status=$stat&";
+                }
+
+                $statuses_string = str_replace(' ', '%20', $statuses_string );
+            }
+
+            /**
              * Build a regular query string for everything else
              */
             foreach( $listing_params as $key => $value ) {
@@ -265,6 +281,7 @@ HTML;
                     && $key !== 'cities'
                     && $key !== 'agent'
                     && $key !== 'type'
+                    && $key !== 'status'
                 ) {
                     $params_string .= $key . "=" . $value . "&";
                 }
@@ -280,6 +297,7 @@ HTML;
             $qs .= $params_string;
             $qs .= $agents_string;
             $qs .= $ptypes_string;
+            $qs .= $statuses_string;
 
             $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $qs, $atts );
             return $listings_content;

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.0.2
+Version: 2.0.3
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
## `v2.0.3`

#### Strip forward slashes from links

Some MLS's use forward slashes in the CDN URL's (eg, ../imgs/\123.png). This strips any forward slash characters from image URL's before trying to show them.

#### Strip forward slashes from links

Allow multiple statuses in the [sr_listings] short-code.