### PR TITLE
Remove backslashes from image url's in sr_listings_slider

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
 # Changelog
 
+## 2.0.4
+* BUGFIX: Fix image rendering when image URL contains forward slashes in sr_listings_slider
+
 ## 2.0.3
-- FEATURE: Allow multiple statuses in the sr_listings short-code.
-- BUGFIX: Fix image rendering when image URL contains forward slashes.
+* FEATURE: Allow multiple statuses in the sr_listings short-code.
+* BUGFIX: Fix image rendering when image URL contains forward slashes.
 
 ## 2.0.2
 * BUGFIX: Fix sr_ptypes query parameter when using multiple property types.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.4
-Stable tag: 2.0.3
+Stable tag: 2.0.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.0.4 =
+* BUGFIX: Fix image rendering when image URL contains forward slashes in sr_listings_slider
 
 = 2.0.3 =
 * FEATURE: Allow multiple statuses in the sr_listings short-code.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1442,6 +1442,7 @@ HTML;
                 $photo = plugins_url( 'assets/img/defprop.jpg', __FILE__ );
             } else {
                 $photo = trim($photos[0]);
+                $photo = str_replace("\\", "", $photo);
             }
 
             $inner .= <<<HTML

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.0.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.0.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.0.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.0.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.0.3
+Version: 2.0.4
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
BUGFIX: v2.0.2 introduced a feature that strips backslashes from image
URL's (or else they cause 404's). This was a spot that was missed in
the last update.