### PR TITLE
[WIP] Add new mappings to listing details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.6
+* FEATURE: Add support for new API fields: LotSizeArea, LotSizeAreaUnits, LotSizeAcres, ListingAgentPreferredEmail, ListingOfficePhone, ListingOfficeEmail.
+
 ## 2.0.5
 * BUGFIX: Resolve better links to listing details pages from the sr_map_search short-code
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.5
-Stable tag: 2.0.5
+Tested up to: 4.5.1
+Stable tag: 2.0.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.0.6 =
+* FEATURE: Add support for new API fields: LotSizeArea, LotSizeAreaUnits, LotSizeAcres, ListingAgentPreferredEmail, ListingOfficePhone, ListingOfficeEmail.
 
 = 2.0.5 =
 * BUGFIX: Resolve better links to listing details pages from the sr_map_search short-code

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -29,6 +29,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_contact_page');
       register_setting('sr_admin_settings', 'sr_show_listingmeta');
       register_setting('sr_admin_settings', 'sr_show_listing_remarks');
+      register_setting('sr_admin_settings', 'sr_show_agent_contact');
       register_setting('sr_admin_settings', 'sr_listing_gallery');
       register_setting('sr_admin_settings', 'sr_show_leadcapture');
       register_setting('sr_admin_settings', 'sr_leadcapture_recipient');
@@ -188,6 +189,17 @@ class SrAdminSettings {
                         . checked(1, get_option('sr_show_listingmeta'), false) . '/>'
                       ?>
                       Hide 'Listing Meta Information' fields from property details?
+                    </label>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_show_agent_contact" name="sr_show_agent_contact" value="1" '
+                        . checked(1, get_option('sr_show_agent_contact'), false) . '/>'
+                      ?>
+                      Do not show Agent and Office phone number and email address (names are still shown).
                     </label>
                   </td>
                 </tr>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -606,6 +606,15 @@ HTML;
         // lot size
         $listing_lotSize = $listing->property->lotSize;
         $lotsize_markup  = SimplyRetsApiHelper::srDetailsTable($listing_lotSize, "Lot Size");
+        // lot size area
+        $listing_lotSizeArea = $listing->property->lotSizeArea;
+        $lotsizearea_markup  = SimplyRetsApiHelper::srDetailsTable($listing_lotSizeArea, "Lot Size Area");
+        // lot size area units
+        $listing_lotSizeAreaUnits = $listing->property->lotSizeAreaUnits;
+        $lotsizeareaunits_markup  = SimplyRetsApiHelper::srDetailsTable($listing_lotSizeAreaUnits, "Lot Size Area Units");
+        // acres
+        $listing_acres = $listing->property->acres;
+        $acres_markup  = SimplyRetsApiHelper::srDetailsTable($acres, "Acres");
         // street address info
         $listing_postal_code = $listing->address->postalCode;
         $postal_code = SimplyRetsApiHelper::srDetailsTable($listing_postal_code, "Postal Code");
@@ -932,6 +941,11 @@ HTML;
                 $bathsTotal
                 $style
                 $lotsize_markup
+
+                $lotsizearea_markup
+                $lotsizeareaunits_markup
+                $acres_markup
+
                 $stories
                 $interiorFeatures
                 $exteriorFeatures

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.0.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.0.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.0.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.0.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -810,10 +810,21 @@ HTML;
             $lh_analytics = '';
         }
 
+        ///////////////////////////////////////////////////////
+
+        $show_contact_info = SrUtils::showAgentContact();
+
         // agent data
         $listing_agent_id    = $listing->agent->id;
         $listing_agent_name  = $listing->agent->firstName . ' ' . $listing->agent->lastName;
-        $listing_agent_email = $listing->agent->contact->email;
+
+        $listing_agent_email;
+        if($show_contact_info) {
+            $listing_agent_email = $listing->agent->contact->email;
+        } else {
+            $listing_agent_email = '';
+        }
+
         // agent email is available
         $agent_email = trim($listing_agent_email);
         if(!empty($agent_email)) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -600,9 +600,6 @@ HTML;
         $listing_modified = $listing->modified;
         if($listing_modified) { $date_modified = date("M j, Y", strtotime($listing_modified)); }
         $date_modified_markup = SimplyRetsApiHelper::srDetailsTable($date_modified, "Listing Last Modified");
-        //listing office
-        $listing_office = $listing->office->name;
-        $office = SimplyRetsApiHelper::srDetailsTable($listing_office, "Listing Office");
         // lot size
         $listing_lotSize = $listing->property->lotSize;
         $lotsize_markup  = SimplyRetsApiHelper::srDetailsTable($listing_lotSize, "Lot Size");
@@ -838,6 +835,23 @@ HTML;
 
         $agent = SimplyRetsApiHelper::srDetailsTable($listing_agent_name, "Listing Agent");
 
+        // Office
+
+        $listing_office = $listing->office->name;
+        $office = SimplyRetsApiHelper::srDetailsTable($listing_office, "Listing Office");
+        $listing_office_phone = $listing->office->contact->office;
+        $officePhone = SimplyRetsApiHelper::srDetailsTable($listing_office_phone, "Listing Office Phone");
+
+        $listing_office_email = $listing->office->contact->email;
+        $officeEmail = SimplyRetsApiHelper::srDetailsTable($listing_office_email, "Listing Office Email");
+
+        if(!$show_contact_info) {
+            $officePhone = '';
+            $officeEmail = '';
+        }
+
+        /////////////////////////////////////////////////////
+
         $galleria_theme = plugins_url('assets/galleria/themes/classic/galleria.classic.min.js', __FILE__);
 
         // Build details link for map marker
@@ -998,6 +1012,8 @@ HTML;
                   <th colspan="3"><h5>Listing Information</h5></th></tr></thead>
               <tbody>
                 $office
+                $officePhone
+                $officeEmail
                 $agent
                 $terms
               </tbody>

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -33,6 +33,21 @@ class SrUtils {
     }
 
     /**
+     * The naming for the database option is backwards.
+     * If it's 'checked', we _don't_ show data.
+     */
+    public static function showAgentContact() {
+
+        if( get_option('sr_show_agent_contact') ) {
+            $show = false;
+        } else {
+            $show = true;
+        }
+
+        return $show;
+    }
+
+    /**
      * Builds a link to a listings' details page. Used in search results.
      */
     public static function buildDetailsLink($listing, $params = array()) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.0.5
+Version: 2.0.6
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Fixes #18 

--

Add support for new API mappings.

- [x] LotSizeArea
- [x] LotSizeAreaUnits
- [x] Acres
- [x] Office contact info
- [x] Agent contact info
- [x] Admin option to hide agent/office contact info (names are still shown, like before).