### PR TITLE
Add support for setting Google Maps API Key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.0
+* FIX: Add admin option for Google Maps API key (which is now required for maps to show on new sites).
+* UPDATE: Various documentation fixes and updates.
+* BUG: Fix 'vendor' parameter initialization in sr_listings_slider short-code.
+* BUG: Fix 'vendor' parameter initialization in sr_map_search short-code.
+
+## 2.0.7
+* BUGFIX: Fix vendor parameter not passed to API calls from widgets
+* BUGFIX: Fix file_get_contents version of API requests.
+
 ## 2.0.6
 * FEATURE: Add support for new API fields: LotSizeArea, LotSizeAreaUnits, LotSizeAcres, ListingAgentPreferredEmail, ListingOfficePhone, ListingOfficeEmail.
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -736,8 +736,12 @@ $_(document).ready(function() {
             startMap();
 
         } else {
+            var key = document.getElementById('sr-map-search').dataset.apiKey;
+
             // if google.maps doesn't exist - load it, then start map
-            var url = "https://maps.googleapis.com/maps/api/js?signed_in=true&libraries=drawing&callback=startMap"
+            var url = "https://maps.googleapis.com/maps/api/js?signed_in=true&libraries=drawing&callback=startMap" +
+                      "&key=" + key;
+
             var script = document.createElement("script");
 
             script.type = "text/javascript";

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -304,6 +304,7 @@ function Map() {
     this.offset     = 0;
     this.linkStyle  = 'default';
     this.siteRoot   = window.location.href
+    this.vendor     = document.getElementById('sr-map-search').dataset.vendor;
 
     this.map     = new google.maps.Map(
         document.getElementById('sr-map-search'), this.options
@@ -598,6 +599,7 @@ Map.prototype.sendRequest = function(points, params, paginate) {
 
     var limit  = this.limit;
     var offset = this.offset;
+    var vendor = this.vendor
 
     /** Remove unused keys */
     for (var p in params) {
@@ -611,7 +613,7 @@ Map.prototype.sendRequest = function(points, params, paginate) {
     var paramsQ = $_.param(params);
 
     /** Put the query in a string and send the request */
-    var query = pointsQ + "&limit=" + limit + "&offset=" + offset + "&" + paramsQ;
+    var query = pointsQ + "&limit=" + limit + "&offset=" + offset + "&vendor=" + vendor + "&" + paramsQ;
 
     var req = $_.ajax({
         type: 'post',

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/CodyReichert/ivory-google-map"
+        }
+    ],
     "require": {
-        "egeloen/google-map": "1.4.1",
+        "egeloen/google-map": "dev-dev-stable",
         "widop/http-adapter": "1.1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "825c25eb87bffc490e587b104aeccab3",
+    "hash": "11f811a25982885aa2822c06871ec3a2",
+    "content-hash": "787345aa111ffcc393e123cd47095185",
     "packages": [
         {
             "name": "egeloen/google-map",
-            "version": "1.4.1",
+            "version": "dev-dev-stable",
             "source": {
                 "type": "git",
-                "url": "https://github.com/egeloen/ivory-google-map.git",
-                "reference": "9770a3f47888494e9f2d449144508bc805af124f"
+                "url": "https://github.com/CodyReichert/ivory-google-map.git",
+                "reference": "5abf51ecea561f03c09f372b2219ecfffc8a4b80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egeloen/ivory-google-map/zipball/9770a3f47888494e9f2d449144508bc805af124f",
-                "reference": "9770a3f47888494e9f2d449144508bc805af124f",
+                "url": "https://api.github.com/repos/CodyReichert/ivory-google-map/zipball/5abf51ecea561f03c09f372b2219ecfffc8a4b80",
+                "reference": "5abf51ecea561f03c09f372b2219ecfffc8a4b80",
                 "shasum": ""
             },
             "require": {
@@ -45,7 +46,6 @@
                     "Ivory\\GoogleMap\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -59,7 +59,10 @@
             "keywords": [
                 "google map"
             ],
-            "time": "2014-10-30 19:30:44"
+            "support": {
+                "source": "https://github.com/CodyReichert/ivory-google-map/tree/dev-stable"
+            },
+            "time": "2016-07-25 20:17:54"
         },
         {
             "name": "egeloen/json-builder",
@@ -115,35 +118,34 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.6.6",
-            "target-dir": "Symfony/Component/PropertyAccess",
+            "version": "v2.8.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/PropertyAccess.git",
-                "reference": "b342f127c3ab73dd4069c2104cb76f1a1ef7c7e7"
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "8fa1fe88f80fd8baefcc71d7cb3007c977d769bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/b342f127c3ab73dd4069c2104cb76f1a1ef7c7e7",
-                "reference": "b342f127c3ab73dd4069c2104cb76f1a1ef7c7e7",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/8fa1fe88f80fd8baefcc71d7cb3007c977d769bd",
+                "reference": "8fa1fe88f80fd8baefcc71d7cb3007c977d769bd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\PropertyAccess\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -151,16 +153,16 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony PropertyAccess Component",
-            "homepage": "http://symfony.com",
+            "homepage": "https://symfony.com",
             "keywords": [
                 "access",
                 "array",
@@ -172,7 +174,7 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2015-03-30 15:54:10"
+            "time": "2016-06-29 05:29:29"
         },
         {
             "name": "widop/http-adapter",
@@ -240,7 +242,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "egeloen/google-map": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.5.3
-Stable tag: 2.0.7
+Stable tag: 2.1.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,11 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.1.0 =
+* FIX: Add admin option for Google Maps API key (which is now required for maps to show on new sites).
+* BUG: Fix 'vendor' parameter initialization in sr_listings_slider short-code
+* BUG: Fix 'vendor' parameter initialization in sr_map_search short-code
 
 = 2.0.7 =
 * BUG: Fix vendor parameter not passed to API calls from widgets

--- a/readme.txt
+++ b/readme.txt
@@ -522,21 +522,21 @@ Refines listings by a certain lot size in Sq Ft (note, this is not area).
 Refines listings by a certain area size in Sq Ft.
 `[sr_listings area="1500"]`
 
-* **cities**
+* ** cities**
 Refines listings to a given set of cities. (Separate multiple with a semi-colon).
 `[sr_listings cities="Houston; Austin; Dallas"]`
 
 * **neighborhoods**
 Refines listings to a given set of neighborhoods/subdivisions. (Separate multiple with a semi-colon).
-`[sr_listings cities="Heights; Downtown; Uptown"]`
+`[sr_listings neighborhoods="Heights; Downtown; Uptown"]`
 
 * **amenities**
 Refines listings to a given set of amenities. (Separate multiple with a semi-colon).
-`[sr_listings cities="Granite; Balcony"]`
+`[sr_listings amenities="Granite; Balcony"]`
 
 * **features**
 Refines listings to a given set of features. (Separate multiple with a semi-colon).
-`[sr_listings cities="Tennis Court; Waterfront"]`
+`[sr_listings features="Tennis Court; Waterfront"]`
 
 * **vendor**
 Refines listings by a certain vendor or MLS Board. (This is required when your account has multiple MLS's).

--- a/readme.txt
+++ b/readme.txt
@@ -538,6 +538,12 @@ Refines listings to a given set of amenities. (Separate multiple with a semi-col
 Refines listings to a given set of features. (Separate multiple with a semi-colon).
 `[sr_listings features="Tennis Court; Waterfront"]`
 
+* **waterfront**
+Refines listings to only ones that have a value for the 'water' field. `true` is the only valid value:
+`[sr_listings waterfront="true"]`
+
+*Note: This is only available for feeds that have a value for 'water'*.
+
 * **vendor**
 Refines listings by a certain vendor or MLS Board. (This is required when your account has multiple MLS's).
 `[sr_listings vendor="MFRMLS"]`

--- a/readme.txt
+++ b/readme.txt
@@ -552,7 +552,7 @@ Returns a set of listings and skips the first *n*, where *n* is the offset.
 
 * **sort**
 Displays the listings in a specific order.
-`[sr_listings sort="price"]`
+`[sr_listings sort="listprice"]`
 
 (The available sort options are `listprice`, `-listprice`, `listdate`, `-listdate`, `baths`, `-baths`, `beds`, and `-beds`.
 Options starting the a minus (-) are high to low, no minus sign is low to high).

--- a/readme.txt
+++ b/readme.txt
@@ -509,7 +509,7 @@ Refines listings by a certain lot size in Sq Ft (note, this is not area).
 Refines listings by a certain area size in Sq Ft.
 `[sr_listings area="1500"]`
 
-* ** cities**
+* **cities**
 Refines listings to a given set of cities. (Separate multiple with a semi-colon).
 `[sr_listings cities="Houston; Austin; Dallas"]`
 
@@ -525,9 +525,9 @@ Refines listings to a given set of amenities. (Separate multiple with a semi-col
 Refines listings to a given set of features. (Separate multiple with a semi-colon).
 `[sr_listings features="Tennis Court; Waterfront"]`
 
-* **waterfront**
+* **water**
 Refines listings to only ones that have a value for the 'water' field. `true` is the only valid value:
-`[sr_listings waterfront="true"]`
+`[sr_listings water="true"]`
 
 *Note: This is only available for feeds that have a value for 'water'*.
 

--- a/readme.txt
+++ b/readme.txt
@@ -265,24 +265,6 @@ listing sidebar widget.
   are much more easily shareable on social media.
 * BUGS: Misc, minor bugs and code cleanup.
 
-= 1.7.2 =
-* FEATURE: Adds the ability to configure sr_search_form to search
-  specified property type(s) via short-code attributes.
-
-= 1.7.1 =
-* BUG FIX: Fix population of property-types dropdown on the
-  sr_map_search search form
-
-= 1.7.0 =
-* FEATURE: Interactive map search! Includes a
-  polygon/rectangle drawing tools on the map. Optional list view and
-  search form.  *Note: Your feed must include latitude/longitude for
-  this to work.*
-* FIX/UPDATE: Featured Listing and Random Listing Widgets now take
-  *listingId's*, not *mlsId's*. This will break existing widgets, so
-  please check them after upgrading.
-
-
 **View the complete CHANGELOG:** [here](https://github.com/SimplyRETS/simplyretswp/blog/master/CHANGELOG)
 
 

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -38,6 +38,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_listhub_analytics_id');
       register_setting('sr_admin_settings', 'sr_search_map_position');
       register_setting('sr_admin_settings', 'sr_permalink_structure');
+      register_setting('sr_admin_settings', 'sr_google_api_key');
   }
 
   public static function adminMessages () {
@@ -352,6 +353,17 @@ class SrAdminSettings {
                       ?>
                       Show Map View Below List View
                     </label>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <br/>
+                    <strong>Google Maps API Key</strong>
+                    <br>
+                    <i>(Required for maps. Get one <a href="https://console.developers.google.com/flows/enableapi?apiid=maps_backend,geocoding_backend,directions_backend,distance_matrix_backend,elevation_backend,places_backend&keyType=CLIENT_SIDE&reusekey=true" target="_blank">here</a>.)</i>
+                  </td>
+                  <td>
+                    <input type="text" name="sr_google_api_key" value="<?php echo esc_attr( get_option('sr_google_api_key') ); ?>" />
                   </td>
                 </tr>
               </tbody>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.0.7 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.1.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.0.7 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.1.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1475,6 +1475,7 @@ HTML;
             $priceUSD = '$' . number_format( $price );
 
             // create link to listing
+            $vendor = isset($settings['vendor']) ? $settings['vendor'] : '';
             $link = SrUtils::buildDetailsLink(
                 $l,
                 !empty($vendor) ? array("sr_vendor" => $vendor) : array()

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -38,6 +38,13 @@ class SrSearchMap {
             'width' => '100%',
             'height' =>  '550px'
         ));
+
+        // Set API key if user has added one.
+        $apik = get_option('sr_google_api_key');
+        if (!empty($apik)) {
+            $map->setApiKey($apik);
+        }
+
         return $map;
     }
 

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -678,8 +678,14 @@ HTML;
 
     public static function sr_listing_slider_shortcode( $atts ) {
         ob_start();
-        $atts['limit'] = empty($atts['limit']) ? 8 : $atts['limit'];
         $settings = array();
+
+        $atts['limit'] = empty($atts['limit']) ? 8 : $atts['limit'];
+
+        if (isset($atts['vendor'])) {
+            $settings['vendor'] = $vendor;
+        }
+
         $settings['random'] = empty($atts['random']) ? NULL : $atts['random'];
         $slider = SimplyRetsApiHelper::retrieveListingsSlider($atts, $settings);
 

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -682,8 +682,8 @@ HTML;
 
         $atts['limit'] = empty($atts['limit']) ? 8 : $atts['limit'];
 
-        if (isset($atts['vendor'])) {
-            $settings['vendor'] = $vendor;
+        if ($atts['vendor']) {
+            $settings['vendor'] = $atts['vendor'];
         }
 
         $settings['random'] = empty($atts['random']) ? NULL : $atts['random'];

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -40,20 +40,20 @@ class SrShortcodes {
     public static function sr_int_map_search($atts) {
         if(!is_array($atts)) $atts = array();
 
-        $content     = "";
-        $search_form = "";
-        $map_markup  = "<div id=\"sr-map-search\"></div>";
-        $list_markup = !empty($atts['list_view'])
-                     ? "<div class=\"sr-map-search-list-view\"></div>"
-                     : "";
-
         /** Private Parameters (shortcode attributes) */
         $vendor   = isset($atts['vendor'])  ? $atts['vendor']  : '';
         $brokers  = isset($atts['brokers']) ? $atts['brokers'] : '';
         $agent    = isset($atts['agent'])   ? $atts['agent']   : '';
         $limit    = isset($atts['limit'])   ? $atts['limit']   : '';
+        $type_att = isset($atts['type'])    ? $atts['type'] : '';
 
-        $type_att = isset($atts['type']) ? $atts['type'] : '';
+        $content     = "";
+        $search_form = "";
+        $gmaps_key   = get_option('sr_google_api_key', '');
+        $map_markup  = "<div id='sr-map-search' data-api-key='{$gmaps_key}' data-vendor='{$vendor}'></div>";
+        $list_markup = !empty($atts['list_view'])
+                     ? "<div class=\"sr-map-search-list-view\"></div>"
+                     : "";
 
         if(!empty($atts['search_form'])) {
 

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.0.7
+Version: 2.1.0
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
As of June 2016, google requires an API key to be specified with every request to the google maps API. This PR adds support for setting an API key in the plugin admin options so that users can add their key and use the maps.

**Notes**
- [x] Needs to be added to server-side _and_ client side map initializations
- [x] Existing sites do _not_ need to specify a key ("Any domains that have been using the google maps API up to this date do not need to specify an API key; only new domains using google maps will receive an error that a key is required".)