### PR TITLE
Add support for multiple counties in sr_listings short-code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.3
+* FEATURE: Add support for multiple counties in sr_listings short-code
+
 ## 2.1.2
 * FIX: Fix missing vendor files
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.5.3
-Stable tag: 2.1.2
+Tested up to: 4.6.0
+Stable tag: 2.1.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 == Changelog ==
 
+= 2.1.3 =
+* FEATURE: Add support for multiple counties in sr_listings short-code
+
 = 2.1.2 =
 * FIX: Fix missing vendor files
 
@@ -405,6 +408,8 @@ The listing slider is a great feature that allows you to build a
 'slider' of listings. See [screenshot #7](https://wordpress.org/plugins/simply-rets/screenshots/)
 for a quick glance of how it works.
 
+*Note: Some attributes (listed below) can take multiple values. sr_listings_slider currently only supports one value per attribute. For example, [sr_listings_slider postalCodes="123456"] is supported, but [sr_listings_slider postalCodes="12345; 34567"] is not.*
+
 **Attributes**
 
 * random
@@ -522,6 +527,14 @@ Refines listings to a given set of cities. (Separate multiple with a semi-colon)
 * **neighborhoods**
 Refines listings to a given set of neighborhoods/subdivisions. (Separate multiple with a semi-colon).
 `[sr_listings neighborhoods="Heights; Downtown; Uptown"]`
+
+* **postalcodes**
+Refines listings to a given set of postal codes. (Separate multiple with a semi-colon).
+`[sr_listings postalcodes="12345; 34567"]`
+
+* **counties**
+Refines listings to a given set of counties. (Separate multiple with a semi-colon).
+`[sr_listings counties="Harris; Travis"]`
 
 * **amenities**
 Refines listings to a given set of amenities. (Separate multiple with a semi-colon).

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.1.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.1.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.1.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.1.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -688,6 +688,10 @@ HTML;
     }
 
 
+    /**
+     * TODO: sr_listings_slider should support attributes that can
+     * take multiple values (eg, postalCodes, counties). #32
+     */
     public static function sr_listing_slider_shortcode( $atts ) {
         ob_start();
         $settings = array();

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -198,6 +198,7 @@ HTML;
          */
         if( !isset($listing_params['neighborhoods'])
             && !isset($listing_params['postalcodes'])
+            && !isset($listing_params['counties'])
             && !isset($listing_params['cities'])
             && !isset($listing_params['agent'])
             && !isset($listing_params['type'])
@@ -256,6 +257,15 @@ HTML;
                 $postalcodes_string = str_replace(' ', '%20', $postalcodes_string );
             }
 
+            if( isset( $listing_params['counties'] ) && !empty( $listing_params['counties'] ) ) {
+                $counties = explode( ';', $listing_params['counties'] );
+                foreach( $counties as $key => $county ) {
+                    $county = trim( $county );
+                    $counties_string .= "counties=$county&";
+                }
+                $counties_string = str_replace(' ', '%20', $counties_string );
+            }
+
             /**
              * Multiple statuses
              */
@@ -277,6 +287,7 @@ HTML;
             foreach( $listing_params as $key => $value ) {
                 // Skip params that support multiple
                 if( $key !== 'postalcodes'
+                    && $key !== 'counties'
                     && $key !== 'neighborhoods'
                     && $key !== 'cities'
                     && $key !== 'agent'
@@ -294,6 +305,7 @@ HTML;
             $qs .= $neighborhoods_string;
             $qs .= $cities_string;
             $qs .= $postalcodes_string;
+            $qs .= $counties_string;
             $qs .= $params_string;
             $qs .= $agents_string;
             $qs .= $ptypes_string;

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.1.2
+Version: 2.1.3
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This adds support for providing multiple counties in the `[sr_listings]` short-code. Eg:

`[sr_listings counties="county1; county2"]`

---

Note: This is only supported in `sr_listings_slider`, not `sr_listings_slider` due to #32 

Fixes #31 