### PR TITLE
Add support for new default API fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.2
+* FEATURE: Add support for more API fields including Garage Spaces, HOA, and more.
+
 ## 2.2.1
 * FIX: Fix pagintation links when using 'counties' parameter
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.6.1
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.2.2 =
+* FEATURE: Add support for more API fields including Garage Spaces, HOA, and more.
 
 = 2.2.1 =
 * FIX: Fix pagination links when using 'counties' parameter

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -895,8 +895,11 @@ HTML;
 
         $agent = SimplyRetsApiHelper::srDetailsTable($listing_agent_name, "Listing Agent");
 
-        // Office
+        $listing_agent_phone = $listing->agent->contact->office;
+        $agent_phone = SimplyRetsApiHelper::srDetailsTable($listing_agent_phone, "Listing Agent Phone");
 
+
+        // Office
         $listing_office = $listing->office->name;
         $office = SimplyRetsApiHelper::srDetailsTable($listing_office, "Listing Office");
         $listing_office_phone = $listing->office->contact->office;
@@ -905,12 +908,16 @@ HTML;
         $listing_office_email = $listing->office->contact->email;
         $officeEmail = SimplyRetsApiHelper::srDetailsTable($listing_office_email, "Listing Office Email");
 
+        /* If show_contact_info is false, stub these fields */
         if(!$show_contact_info) {
+            $agent_phone = '';
             $officePhone = '';
             $officeEmail = '';
         }
 
+
         $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office);
+
 
         $galleria_theme = plugins_url('assets/galleria/themes/classic/galleria.classic.min.js', __FILE__);
 
@@ -1083,6 +1090,7 @@ HTML;
                 $officePhone
                 $officeEmail
                 $agent
+                $agent_phone
                 $terms
               </tbody>
               $school_data

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -699,6 +699,18 @@ HTML;
             $listing_association_amenities, "Association Amenities"
         );
 
+        // Virtual tour URL
+        $listing_virtual_tour = $listing->virtualTourUrl;
+        if (!empty($listing_virtual_tour)) {
+            // Make the URL a link
+            $listing_virtual_tour = "<a href='$listing_virtual_tour' target='_blank'>"
+                                  . $listing_virtual_tour
+                                  . "</a>";
+
+        }
+
+        $virtual_tour = SimplyRetsApiHelper::srDetailsTable($listing_virtual_tour, "Virtual Tour URL");
+
 
         // area
         $area = $listing->property->area == 0
@@ -1092,6 +1104,7 @@ HTML;
                 $agent
                 $agent_phone
                 $terms
+                $virtual_tour
               </tbody>
               $school_data
               <thead>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -567,6 +567,12 @@ HTML;
         // tax data
         $listing_taxdata = $listing->tax->id;
         $tax_data = SimplyRetsApiHelper::srDetailsTable($listing_taxdata, "Tax ID");
+        // tax year
+        $listing_tax_year = $listing->tax->taxYear;
+        $tax_year = SimplyRetsApiHelper::srDetailsTable($listing_tax_year, "Tax Year");
+        // tax annual amount
+        $listing_tax_annual_amount = $listing->tax->taxAnnualAmount;
+        $tax_annual_amount = SimplyRetsApiHelper::srDetailsTable($listing_tax_annual_amount, "Tax Annual Amount");
         // roof
         $listing_roof = $listing->property->roof;
         $roof = SimplyRetsApiHelper::srDetailsTable($listing_roof, "Roof");
@@ -666,6 +672,33 @@ HTML;
         $listing_lease_type = $listing->leaseType;
         $lease_type = SimplyRetsApiHelper::srDetailsTable($listing_lease_type, "Lease Type");
 
+        $listing_pool = $listing->property->pool;
+        $pool = SimplyRetsApiHelper::srDetailsTable($listing_pool, "Pool features");
+
+        // Garage and Parking info
+        $listing_garage_spaces = $listing->property->garageSpaces;
+        $garage_spaces = SimplyRetsApiHelper::srDetailsTable($listing_garage_spaces, "Garage spaces");
+
+        $listing_parking_spaces = $listing->property->parking->spaces;
+        $parking_spaces = SimplyRetsApiHelper::srDetailsTable($listing_parking_spaces, "Parking Spaces");
+
+        $listing_parking_description = $listing->property->parking->description;
+        $parking_description = SimplyRetsApiHelper::srDetailsTable(
+            $listing_parking_description, "Parking Description"
+        );
+
+        // association data
+        $listing_association_fee = $listing->association->fee;
+        $association_fee = SimplyRetsApiHelper::srDetailsTable($listing_association_fee, "Association Fee");
+
+        $listing_association_name = $listing->association->name;
+        $association_name = SimplyRetsApiHelper::srDetailsTable($listing_association_name, "Association Name");
+
+        $listing_association_amenities = $listing->association->amenities;
+        $association_amenities = SimplyRetsApiHelper::srDetailsTable(
+            $listing_association_amenities, "Association Amenities"
+        );
+
 
         // area
         $area = $listing->property->area == 0
@@ -692,8 +725,8 @@ HTML;
         }
 
 
+        // Rooms data
         $roomsMarkup = '';
-
         if(is_array($listing->property->rooms)) {
 
             $rooms = $listing->property->rooms;
@@ -785,11 +818,12 @@ HTML;
 
         // list date and listing last modified
         $show_listing_meta = SrUtils::srShowListingMeta();
-
         if($show_listing_meta !== true) {
             $list_date = '';
             $date_modified_markup = '';
             $tax_data = '';
+            $tax_year = '';
+            $tax_annual_amount = '';
         }
 
         if( get_option('sr_show_listing_remarks') ) {
@@ -1012,6 +1046,13 @@ HTML;
                 $accessibility
                 $lot_description
                 $laundry_features
+                $pool
+                $parking_description
+                $parking_spaces
+                $garage_spaces
+                $association_name
+                $association_fee
+                $association_amenities
                 $additional_rooms
                 $roomsMarkup
               </tbody>
@@ -1054,6 +1095,8 @@ HTML;
                 $list_date
                 $date_modified_markup
                 $tax_data
+                $tax_year
+                $tax_annual_amount
                 $mls_area
                 $mlsid
               </tbody>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.2.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.2.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.2.1
+Version: 2.2.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
These are (mostly) fields that used to be hidden behind the 'include'
parameter. They are now included in the API response by default, so we
can show the fields on listing details pages.

This adds support for:
- [x] garageSpaces
- [x] parking.spaces
- [x] parking.description
- [x] association.fee
- [x] association.name
- [x] association.amenities
- [x] tax.taxYear
- [x] tax.taxAnnualAmount
- [x] pool
- [x] agent.contact.preferredPhone
- [x] virtualTourUrl