### PR TITLE
Remove 'lotsize' parameter from documentation.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.3
+* DOCUMENTATION: Remove unsupported 'lotsize' parameter from documentation.
+
 ## 2.2.2
 * FEATURE: Add support for more API fields including Garage Spaces, HOA, and more.
 

--- a/readme.txt
+++ b/readme.txt
@@ -499,10 +499,6 @@ Refines listings to a specific agent by taking an agent's MLS ID.
 Refines listings to a specific brokerage by taking a brokerage's MLS ID.
 `[sr_listings brokers="KWREALTY1"]`
 
-* **lotsize**
-Refines listings by a certain lot size in Sq Ft (note, this is not area).
-`[sr_listings lotsize="5000"]`
-
 * **area**
 Refines listings by a certain area size in Sq Ft.
 `[sr_listings area="1500"]`

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.6.1
-Stable tag: 2.2.2
+Tested up to: 4.7
+Stable tag: 2.2.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.2.3 =
+* DOCUMENTATION: Remove unsupported 'lotsize' parameter from documentation.
 
 = 2.2.2 =
 * FEATURE: Add support for more API fields including Garage Spaces, HOA, and more.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.2.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.2.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.2.2
+Version: 2.2.3
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This parameter is not available and was incorrectly put into the
documentation. This will need to be added at the API level before it can
be supported in the plugin.

- Bump version to 2.2.3
- Bump stable tag to 4.7