### PR TITLE
Add contact form info to the body of the email message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.5
+* FEATURE: Add contact form info (name, email, listing) to the end of the email message body.
+
 ## 2.2.4
 * BUGFIX: Don't send empty 'status' and 'type' parameters to the API.
 * DOCUMENTATION: Update documentation for 'area' parameter.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.7
-Stable tag: 2.2.4
+Tested up to: 4.7.1
+Stable tag: 2.2.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.2.5 =
+* FEATURE: Add contact form info (name, email, listing) to the end of the email message body.
 
 = 2.2.4 =
 * BUGFIX: Don't send empty 'status' and 'type' parameters to the API.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.2.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.2.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1547,7 +1547,16 @@ HTML;
             $name    = sanitize_text_field( $_POST["sr-cf-name"] );
             $email   = sanitize_email( $_POST["sr-cf-email"] );
             $subject = sanitize_text_field( $_POST["sr-cf-subject"] );
-            $message = esc_textarea( $_POST["sr-cf-message"] ) . ' - ' . $listing;
+            $message = esc_textarea( $_POST["sr-cf-message"] )
+                     . "\r\n" . "\r\n"
+                     . "Form submission information: "
+                     . "\r\n"
+                     . "Listing: " . $listing
+                     . "\r\n"
+                     . "Name: " . $name
+                     . "\r\n"
+                     . "Email: " . $email
+                     ;
 
             // get the blog administrator's email address
             $to = get_option('sr_leadcapture_recipient', '');

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.2.4
+Version: 2.2.5
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This fixes cases where the contact form's email "From" header gets
overwritten by email providers that don't allow custom values in the
"From" header.

Situation:
In some cases, like Gmail, an email's "From" header is overwritten to be
the email that was used to authenticate with SMTP. Right now, our
contact form relies on the "From" header being set to the email that was
entered with the form.

In these situations, the "From" email address is completely lost which
makes the contact form email basically useless since you don't know how
submitted the form.

Solution:
This adds all of the contact form information (Name, email, and current
listing) to the end of the email message so that if the "From" header is
overwritten, the information is still available in the body of the
message and can be copied out.

---

![screenshot-mail google com-2017-01-23-12-29-27](https://cloud.githubusercontent.com/assets/7034627/22217173/9f48591a-e167-11e6-9279-10d1700e318f.png)
