### PR TITLE
Add admin option to show MLS status text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.6
+* FEATURE: Add admin option to use "statusText" API field in place of the standardized status.
+
 ## 2.2.5
 * FEATURE: Add contact form info (name, email, listing) to the end of the email message body.
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -101,9 +101,9 @@ var buildUglyLink = function(mlsId, address, root) {
 }
 
 
-var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails) {
+var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText) {
 
-    var stat  = listing.mls.status         || "Active";
+    var stat  = statusText ? listing.mls.statusText : listing.mls.status;
     var baths = listing.property.bathsFull || "n/a";
     var beds  = listing.property.bedrooms  || "n/a";
     var style = listing.property.style     || "Res" ;
@@ -155,7 +155,7 @@ var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThum
 }
 
 
-var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, officeOnThumbnails) {
+var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText) {
     // if(!listings || listings.length < 1) return [];
 
     var markers = [];
@@ -170,7 +170,7 @@ var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, office
 
             var bound  = new google.maps.LatLng(listing.geo.lat, listing.geo.lng);
 
-            var popup  = genMarkerPopup(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails);
+            var popup  = genMarkerPopup(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText);
 
             var window = new google.maps.InfoWindow({
                 content: popup
@@ -506,6 +506,7 @@ Map.prototype.handleRequest = function(that, data) {
     var idxImg = document.getElementById('sr-map-search').dataset.idxImg;
     var officeOnThumbnails = document.getElementById('sr-map-search').dataset.officeOnThumbnails;
     var linkStyle = data.permalink_structure === "" ? "default" : "pretty";
+    var statusText = data.show_mls_status_text;
 
     that.siteRoot = data.site_root
     that.linkStyle = linkStyle;
@@ -518,7 +519,8 @@ Map.prototype.handleRequest = function(that, data) {
                                 , that.linkStyle
                                 , that.siteRoot
                                 , idxImg
-                                , officeOnThumbnails);
+                                , officeOnThumbnails
+                                , statusText );
 
     that.bounds   = markers.bounds;
     that.markers  = markers.markers;

--- a/readme.txt
+++ b/readme.txt
@@ -593,21 +593,75 @@ sidebar and footer. The currently available widgets include:
 This sections will discuss some of the basic configuration options
 available to admin's through the plugin:
 
-* **Permalinks**
-  SimplyRETS has support for 'pretty' and 'ugly' permalinks. It will
-  choose the best one based on your current configuration and there
-  are a couple of options to fine-tune it.
+= Account credentials =
 
-  - If your WordPress site uses 'default' (ugly) permalinks, the
-    plugin is forced to use those as well.
+The account credentials section in the admin settings is where you'll
+enter your API Credentials for your SimplyRETS app. If you don't yet
+have a SimplyRETS app, the default *demo* credentials will be
+available.
 
-  - If your WordPress site is using 'pretty' permalinks, you can
-    choose between 'pretty' and 'extra pretty' SimplyRETS links in the
-    "Permalnks" section of the admin panel. Here are some basic
-    examples:
+= Single Listing Page Settings =
 
-  *Pretty*: http://yoursite.com/listings/{id}/{streetAddress}
-  *Extra Pretty*: http://yoursite.com/listings/{city}/{state}/{postalCode}/{streetAddress}/{id}
+These settings allow you to control various parts of the listing
+details pages, including the contact form and some of the fields that
+are shown.
+
+**Contact form lead capture**
+
+When this is enabled, a lead capture contact form will be shown at the
+bottom of listing details pages. In the *Send lead capture form
+submissions to* input, you can enter the email address where you'd
+like to receive lead emails.
+
+*Note: The WordPress admin email is used if no email is provided*
+
+**Show/Hide fields**
+
+Show and/or hide various parts of the listing details page:
+
+* Hide 'Listing meta information' fields from property details?
+  This option hides `listDate`, `modificationTimestamp`, `taxYear`,
+  and `taxAmmount` from listing details pages.
+
+* Do not show Agent/Office phone number and email address
+  If checked, the listing office and agent's contact information will
+  not be shown. Note that, in most cases, the name will still be
+  shown.
+
+* Hide 'Listing Remarks' (description) field from property details?
+  If checked, the listing description will not be dispayed.
+
+* Show additional room details?
+  If available, extra information about the listing's rooms will be
+  shown when this is enabled.
+
+* Show MLS status text if available (hide standardized status)?
+  If a `statusText` is available for the listing, show that instead of
+  the standardized status. Read more about `statusText`
+  [here](https://docs.simplyrets.com/api/index.html#!/default/get_properties)
+
+= Image gallery settings =
+
+There are two types of image galleries available for listing details
+pages: *fancy* and *classic*. Here, you can choose which one you'd
+like to use.
+
+**Permalinks**
+
+SimplyRETS has support for 'pretty' and 'ugly' permalinks. It will
+choose the best one based on your current configuration and there
+are a couple of options to fine-tune it.
+
+- If your WordPress site uses 'default' (ugly) permalinks, the
+  plugin is forced to use those as well.
+
+- If your WordPress site is using 'pretty' permalinks, you can
+  choose between 'pretty' and 'extra pretty' SimplyRETS links in the
+  "Permalnks" section of the admin panel. Here are some basic
+  examples:
+
+*Pretty*: http://yoursite.com/listings/{id}/{streetAddress}
+*Extra Pretty*: http://yoursite.com/listings/{city}/{state}/{postalCode}/{streetAddress}/{id}
 
 
 == MLS Compliance Settings ==

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.7.1
-Stable tag: 2.2.5
+Tested up to: 4.7.2
+Stable tag: 2.2.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.2.6 =
+ * FEATURE: Add admin option to use "statusText" API field in place of the standardized status.
 
 = 2.2.5 =
 * FEATURE: Add contact form info (name, email, listing) to the end of the email message body.

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -42,6 +42,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_office_on_thumbnails');
       register_setting('sr_admin_settings', 'sr_thumbnail_idx_image');
       register_setting('sr_admin_settings', 'sr_custom_disclaimer');
+      register_setting('sr_admin_settings', 'sr_show_mls_status_text');
   }
 
   public static function adminMessages () {
@@ -234,6 +235,18 @@ class SrAdminSettings {
                         . checked(1, get_option('sr_additional_rooms'), false) . '/>'
                       ?>
                       Show additional room details?
+                    </label>
+                  </td>
+                </tr>
+
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_show_mls_status_text" name="sr_show_mls_status_text" value="1" '
+                        . checked(1, get_option('sr_show_mls_status_text'), false) . '/>'
+                      ?>
+                      Show MLS status text if available (hide standardized status)?
                     </label>
                   </td>
                 </tr>

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -246,7 +246,7 @@ class SrAdminSettings {
                         '<input type="checkbox" id="sr_show_mls_status_text" name="sr_show_mls_status_text" value="1" '
                         . checked(1, get_option('sr_show_mls_status_text'), false) . '/>'
                       ?>
-                      Show MLS status text if available (hide standardized status)?
+                      Show MLS status text if available (in place of standardized status)?
                     </label>
                   </td>
                 </tr>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -521,6 +521,15 @@ HTML;
         // internal unique id
         $listing_uid = $listing->mlsId;
 
+        /**
+         * Get the listing status to show. Note that if the
+         * sr_show_mls_status_text admin option is set to true, we
+         * will show the listing's "statusText" and not the normalized
+         * status.
+         */
+        $listing_mls_status = SrListing::listingStatus($listing);
+        $mls_status = SimplyRetsApiHelper::srDetailsTable($listing_mls_status, "MLS Status");
+
         // price
         $listing_price = $listing->listPrice;
         $listing_price_USD = '$' . number_format( $listing_price );
@@ -585,9 +594,6 @@ HTML;
         // unit
         $listing_unit = $listing->address->unit;
         $unit = SimplyRetsApiHelper::srDetailsTable($listing_unit, "Unit");
-        // mls information
-        $listing_mls_status     = $listing->mls->status;
-        $mls_status = SimplyRetsApiHelper::srDetailsTable($listing_mls_status, "MLS Status");
         // int/ext features
         $listing_interiorFeatures = $listing->property->interiorFeatures;
         $interiorFeatures = SimplyRetsApiHelper::srDetailsTable($listing_interiorFeatures, "Features");
@@ -1211,7 +1217,6 @@ HTML;
             $listing_agent_name = $listing->agent->firstName . ' ' . $listing->agent->lastName;
             $lng                = $listing->geo->lng;
             $lat                = $listing->geo->lat;
-            $mls_status         = $listing->mls->status;
             $propType           = $listing->property->type;
             $bedrooms           = $listing->property->bedrooms;
             $bathsFull          = $listing->property->bathsFull;
@@ -1222,6 +1227,11 @@ HTML;
             $subdivision        = $listing->property->subdivision;
             $style              = $listing->property->style;
             $yearBuilt          = $listing->property->yearBuilt;
+
+            /**
+             * Listing status to show. This may return a statusText.
+             */
+            $mls_status = SrListing::listingStatus($listing);
 
             $addrFull = $address . ', ' . $city . ' ' . $zip;
             $listing_USD = $listing_price == "" ? "" : '$' . number_format( $listing_price );
@@ -1435,17 +1445,21 @@ HTML;
 
         foreach ( $response as $listing ) {
             $listing_uid = $listing->mlsId;
+            $listing_remarks  = $listing->remarks;
+
             // widget details
             $bedrooms = $listing->property->bedrooms;
             if( $bedrooms == null || $bedrooms == "" ) {
                 $bedrooms = 0;
             }
+
             $bathsFull   = $listing->property->bathsFull;
             if( $bathsFull == null || $bathsFull == "" ) {
                 $bathsFull = 0;
             }
-            $mls_status    = $listing->mls->status;
-            $listing_remarks  = $listing->remarks;
+
+            $mls_status = SrListing::listingStatus($listing);
+
             $listing_price = $listing->listPrice;
             $listing_USD   = '$' . number_format( $listing_price );
 

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.2.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.2.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.2.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -131,6 +131,7 @@ HTML;
            && $_POST['action'] === "update_int_map_data") {
 
             $permalink_struct = get_option('permalink_structure');
+            $showStatusText = get_option('sr_show_mls_status_text', false);
             $site_root = get_site_url();
 
             header("Content-Type: application/json");
@@ -147,6 +148,7 @@ HTML;
                 "markup" => $con,
                 "post"   => $_POST,
                 "permalink_structure" => $permalink_struct,
+                "show_mls_status_text" => $showStatusText,
                 "site_root" => $site_root
             );
 

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -236,6 +236,19 @@ class SrUtils {
 }
 
 
+class SrListing {
+
+    /**
+     * Return a 'display-ready' status for a listing. Checks the
+     * sr_show_mls_status_text option and returns either the
+     * statusText or status for the listing.
+     */
+    public static function listingStatus($listing) {
+        $useStatusText = get_option('sr_show_mls_status_text', false);
+        return $useStatusText ? $listing->mls->statusText : $listing->mls->status;
+    }
+}
+
 
 class SrMessages {
 

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.2.5
+Version: 2.2.6
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
A new field "statusText" has been added to the MlsInformation in the API
response. This adds an option to the admin panel that, if set to true,
will show the raw MLS statusText field in place of the standard status
field.

For example, this may have the effect in some areas of showing the raw
"Contingent" status on a listing that has a standardized status of
"Active".

Note that the statusText can be shown, but not searched. Any status=
searches still work on the standard mls.status even when this option is
true.

---

- [x] Add admin option
- [x] Add `SrListing` class help to format `status` for display
- [x] Support `[sr_map_search]`, `[sr_listings]`, `[sr_listings_slider]` and all widgets
- [x] Update documentation for admin options

![screenshot-localhost 8080-2017-02-06-12-53-50](https://cloud.githubusercontent.com/assets/7034627/22661559/6695beaa-ec6b-11e6-9efe-2fb378918196.png)