### PR TITLE
Prioritize 'bathrooms' over 'bathsFull' in results list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0
+* FEATURE: Prioritize bathrooms over bathsFull in results list details
+* UPDATE: Update compatibility with latest WordPress version 4.8
+
 ## 2.2.6
 * FEATURE: Add admin option to use "statusText" API field in place of the standardized status.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.7.2
-Stable tag: 2.2.6
+Tested up to: 4.8
+Stable tag: 2.3.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,8 +235,12 @@ listing sidebar widget.
 
 == Changelog ==
 
+= 2.3.0 =
+* FEATURE: Prioritize bathrooms over bathsFull in results list details
+* UPDATE: Update compatibility with latest WordPress version 4.8
+
 = 2.2.6 =
- * FEATURE: Add admin option to use "statusText" API field in place of the standardized status.
+* FEATURE: Add admin option to use "statusText" API field in place of the standardized status.
 
 = 2.2.5 =
 * FEATURE: Add contact form info (name, email, listing) to the end of the email message body.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.2.6 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.2.6 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1305,7 +1305,6 @@ HTML;
              * TODO: Create a ranking system 1 - 10 to smartly replace missing values
              */
             $bedsMarkup  = SimplyRetsApiHelper::resultDataColumnMarkup($bedrooms, 'Bedrooms');
-            $bathsMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($bathsFull, 'Full Baths');
             $areaMarkup  = SimplyRetsApiHelper::resultDataColumnMarkup(
                 $area, '<span class="sr-listing-area-sqft">SqFt</span>'
             );
@@ -1324,9 +1323,19 @@ HTML;
                 $yearMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($subdivision, "");
             }
 
-            if(empty($bathsFull) || $bathsFull == 0 && is_numeric($bathsTotal)) {
-                $realBaths   = $bathsTotal + 0;
-                $bathsMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($realBaths, "Bath");
+
+            /**
+             * Get the 'best' number for the total baths.
+             * Prioritize 'bathrooms' (eg, total baths) over
+             * bathsFull, and only fallback to bathsFull if bathrooms
+             * is not available.
+             */
+            $bathsMarkup;
+            if(is_numeric($bathsTotal)) {
+                $total_baths = $bathsTotal + 0; // strips extraneous decimals
+                $bathsMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($total_baths, 'Bath');
+            } else {
+                $bathsMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($bathsFull, 'Full Baths');
             }
 
 

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.2.6
+Version: 2.3.0
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This makes the 'Baths' field shown in the results view consistent with
the 'Baths' shown on a listing's primary details area.

- Always try to use 'bathrooms' first. Make sure it's numeric so it
  displays properly.
- If it's not available, or not numeric, fall back to bathsFull