### PR TITLE
Allow initial 'cities' to be set in advanced search form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.1
+* BUGFIX: Allow default 'cities' to be selected in advanced search form
+
 ## 2.3.0
 * FEATURE: Prioritize bathrooms over bathsFull in results list details
 * UPDATE: Update compatibility with latest WordPress version 4.8

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.1 =
+* BUGFIX: Allow default 'cities' to be selected in advanced search form
 
 = 2.3.0 =
 * FEATURE: Prioritize bathrooms over bathsFull in results list details

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.0 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.1 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.0 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.1 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -390,8 +390,17 @@ HTML;
         $lotsize    = array_key_exists('lotsize',  $atts) ? $atts['lotsize']  : '';
         $area       = array_key_exists('area',     $atts) ? $atts['area']     : '';
         $adv_features      = isset($_GET['sr_features']) ? $_GET['sr_features'] : array();
-        $adv_cities        = isset($_GET['sr_cities']) ? $_GET['sr_cities']     : array();
         $adv_neighborhoods = isset($_GET['sr_neighborhoods']) ? $_GET['sr_neighborhoods']     : array();
+
+        /*
+         * Get the initial values for `cities`. If a query parameter
+           is set, use-that, otherwise check for a 'cities' attribute
+           on the [sr_search_form] short-code
+         */
+        $adv_cities = isset($_GET['sr_cities']) ? $_GET['sr_cities'] : array();
+        if (empty($adv_cities) && array_key_exists('cities', $atts)) {
+            $adv_cities = $atts['cities'];
+        }
 
         if( !$sort  == "" ) {
             $sort_price_hl = ($sort == "-listprice") ? "selected" : '';

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.0
+Version: 2.3.1
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
In the advanced [sr_search_form], allow an initial 'cities' value to be
set. For example: [sr_search_form cities="Austin"]. Will automatically
highlight "Austin" in the advanced search form cities select box.

The behavior to have default selections was already implemented, but was
only using query parameters, not short-code attributes.