### PR TITLE
Add schema microdata to properties markup

### DIFF
--- a/assets/css/simply-rets-client.css
+++ b/assets/css/simply-rets-client.css
@@ -18,6 +18,21 @@ CSS to add styles.
 *Licensed under the GNU GPL version 3 or later.*
 */
 
+.sr-hide {
+    display: none !important;
+}
+
+.sr-screen-reader {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
 /*
 Listing Results
 ===
@@ -70,7 +85,6 @@ of the image, use this class.
     background-position: center center;
     background-repeat: no-repeat;
 }
-
 
 /*
 Primary Data
@@ -177,7 +191,6 @@ is to change the `margin-left` property to align better in some themes.
     width: 70%;
 }
 
-
 /*
 Notice that we also provide you with `sr-data-column` for
 managing the spacing and margin between the two columns of
@@ -190,8 +203,6 @@ secondary data. For example, set the `.sr-data-column` to
     vertical-align: top;
     min-width: 15%;
 }
-
-
 
 /*
 Listing Details
@@ -248,10 +259,10 @@ without affecting the overall look of the section.
 ```
 */
 .sr-primary-details {
-  display: flex;
-  justify-content: space-between;
-  clear: both;
-  padding-top: 15px;
+    display: flex;
+    justify-content: space-between;
+    clear: both;
+    padding-top: 15px;
 }
 
 /*
@@ -370,7 +381,6 @@ standard class names like `button` and `btn`.
     margin-top: 5px;
     margin-bottom: 10px !important;
 }
-
 
 /**
  * SimplyRETS Search Form Widget
@@ -564,7 +574,7 @@ elsewhere, this should be a breeze.
 ```
 
 */
-.sr-slider{
+.sr-slider {
     max-width: 650px;
     width: 100%;
     position: relative;
@@ -574,7 +584,7 @@ elsewhere, this should be a breeze.
     transition: all 0.5s;
 }
 
-.sr-slider>img{
+.sr-slider > img {
     position: absolute;
     left: 0;
     top: 0;
@@ -604,7 +614,7 @@ elsewhere, this should be a breeze.
     display: none;
 }
 
-.sr-slider input[name='slide_switch']:checked+label {
+.sr-slider input[name='slide_switch']:checked + label {
     border-color: #666;
     opacity: 1;
 }
@@ -612,7 +622,7 @@ elsewhere, this should be a breeze.
     opacity: 0;
     transform: scale(1.1);
 }
-.sr-slider input[name='slide_switch']:checked+label+img {
+.sr-slider input[name='slide_switch']:checked + label + img {
     opacity: 1;
     transform: scale(1);
 }
@@ -634,7 +644,6 @@ elsewhere, this should be a breeze.
 .galleria-errors {
     display: none !important;
 }
-
 
 /**
   * Advanced Search Form
@@ -660,7 +669,6 @@ elsewhere, this should be a breeze.
 .sr-adv-search-wrap .sr-minmax-filters {
     margin-bottom: 0px;
 }
-
 
 /** Single Column */
 .sr-adv-search-part .sr-adv-search-col1 {
@@ -755,7 +763,6 @@ elsewhere, this should be a breeze.
         width: 50%;
     }
 }
-
 
 /*
  * Responsive CSS
@@ -855,7 +862,6 @@ elsewhere, this should be a breeze.
     font-size: 23px !important;
 }
 
-
 /** Listing Slider */
 .sr-listing-slider-item {
     padding: 10px;
@@ -873,8 +879,7 @@ elsewhere, this should be a breeze.
     margin-top: 10px;
 }
 
-.sr-listing-slider-item-price,
-.sr-listing-slider-item-specs {
+.sr-listing-slider-item-price, .sr-listing-slider-item-specs {
     margin-bottom: 5px !important;
     text-align: center;
 }

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1210,6 +1210,7 @@ HTML;
             $listing_price      = $listing->listPrice;
             $remarks            = $listing->remarks;
             $city               = $listing->address->city;
+            $state              = $listing->address->state;
             $county             = $listing->geo->county;
             $address            = $listing->address->full;
             $zip                = $listing->address->postalCode;
@@ -1342,8 +1343,15 @@ HTML;
             // append markup for this listing to the content
             $resultsMarkup .= <<<HTML
               <hr>
-              <div class="sr-listing">
+              <div class="sr-listing" itemscope itemtype="http://schema.org/SingleFamilyResidence">
+                <span class="sr-hide" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+                  <span itemprop="streetAddress">$address</span>
+                  <span itemprop="addressLocality">$city</span>
+                  <span itemprop="addressRegion">$state</span>
+                  <span itemptop="postalCode">$zip</span>
+                </span>
                 <a href="$link">
+                  <meta itemprop="image" content="$main_photo"></meta>
                   <div class="sr-photo" style="background-image:url('$main_photo');">
                   </div>
                 </a>
@@ -1372,6 +1380,10 @@ HTML;
                     </span>
                     $compliance_markup
                   </div>
+                </div>
+                <div class="sr-screen-reader" itemprop="geo" itemscope itemtype="http://schema.org/GeoCoordinates">
+                  <meta content="$lat" itemprop="latitude">
+                  <meta content="$lng" itemprop="longitude"
                 </div>
               </div>
 HTML;

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -533,7 +533,8 @@ HTML;
         // price
         $listing_price = $listing->listPrice;
         $listing_price_USD = '$' . number_format( $listing_price );
-        $price = SimplyRetsApiHelper::srDetailsTable($listing_price_USD, "Price");
+        $listing_price_markup = "<span itemprop='offers' itemscope itemtype='http://schema.org/Offer'><span itemprop='price' content='$listing_price'>$listing_price_USD</span><meta itemprop='priceCurrency' content='USD'></span>";
+        $price = SimplyRetsApiHelper::srDetailsTable($listing_price_markup, "Price");
         // type
         $listing_type = $listing->property->type;
         $type = SimplyRetsApiHelper::srDetailsTable($listing_type, "Property Type");
@@ -1000,7 +1001,17 @@ HTML;
 
         // listing markup
         $cont .= <<<HTML
-          <div class="sr-details" style="text-align:left;">
+          <div class="sr-details" itemscope itemtype="http://schema.org/Product" style="text-align:left;">
+            <link itemprop="additionalType" href="http://www.productontology.org/id/Real_estate">
+            <span class="sr-screen-reader" itemprop="name" content="$listing_address, $listing_city, $listing_state $listing_postal_code">
+              <span itemscope itemtype="http://schema.org/PostalAddress">
+                <span itemprop="streetAddress">$listing_address</span>
+                <span itemprop="addressLocality">$listing_city</span>
+                <span itemprop="addressRegion">$listing_state</span>
+                <span itemptop="postalCode">$listing_postal_code</span>
+              </span>
+            </span>
+            <meta itemprop="image" content="$photos[0]">
             <p class="sr-details-links" style="clear:both;">
               $mapLink
               $more_photos
@@ -1025,21 +1036,23 @@ HTML;
                   Galleria.run('.sr-gallery');
               }
             </script>
-            <div class="sr-primary-details">
-              <div class="sr-detail" id="sr-primary-details-beds">
-                <h3>$listing_bedrooms <small>Beds</small></h3>
+            <div itemprop="description">
+              <div class="sr-primary-details">
+                <div class="sr-detail" id="sr-primary-details-beds">
+                  <h3>$listing_bedrooms <small>Beds</small></h3>
+                </div>
+                <div class="sr-detail" id="sr-primary-details-baths">
+                  <h3>$primary_baths<small> Baths</small></h3>
+                </div>
+                <div class="sr-detail" id="sr-primary-details-size">
+                  <h3>$area <small class="sr-listing-area-sqft">SqFt</small></h3>
+                </div>
+                <div class="sr-detail" id="sr-primary-details-status">
+                  <h3>$listing_mls_status</h3>
+                </div>
               </div>
-              <div class="sr-detail" id="sr-primary-details-baths">
-                <h3>$primary_baths<small> Baths</small></h3>
-              </div>
-              <div class="sr-detail" id="sr-primary-details-size">
-                <h3>$area <small class="sr-listing-area-sqft">SqFt</small></h3>
-              </div>
-              <div class="sr-detail" id="sr-primary-details-status">
-                <h3>$listing_mls_status</h3>
-              </div>
-            </div>
-            $remarks_markup
+              $remarks_markup
+            </div> 
             <table style="width:100%;">
               <thead>
                 <tr>


### PR DESCRIPTION
This adds schema.org markup to properties within the property listings and also on single property pages. 

I am using the SingleFamilyResidence for the property listings and the product schema for single property views. 

**Reference**
[SingleFamilyResidence schema](http://schema.org/SingleFamilyResidence)
[Product schema](http://schema.org/Product)