### PR TITLE
Improve logic for displaying baths in [sr_listings_slider]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.2
+* FEATURE: Prioritize bathrooms over bathsFull in [sr_listings_slider]
+* UPDATE: Update compatibility with latest WordPress version 4.8.1
+
 ## 2.3.1
 * BUGFIX: Allow default 'cities' to be selected in advanced search form
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.8
-Stable tag: 2.3.1
+Tested up to: 4.8.1
+Stable tag: 2.3.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.2 =
+* FEATURE: Prioritize bathrooms over bathsFull in [sr_listings_slider]
+* UPDATE: Update compatibility with latest WordPress version 4.8.1
 
 = 2.3.1 =
 * BUGFIX: Allow default 'cities' to be selected in advanced search form

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1614,7 +1614,6 @@ HTML;
             $price   = $l->listPrice;
             $photos  = $l->photos;
             $beds    = $l->property->bedrooms;
-            $baths   = $l->property->bathsFull;
             $area    = $l->property->area;
 
             $priceUSD = '$' . number_format( $price );
@@ -1638,6 +1637,24 @@ HTML;
                 $photo = trim($photos[0]);
                 $photo = str_replace("\\", "", $photo);
             }
+
+            /**
+             * Get the best number for 'baths'. Prioritize `bathrooms`
+             * over `bathsFull`, and only use `bathsFull` if
+             * `bathrooms` is not available. This is the same display
+             * logic used in the [sr_listings] short-code.
+             */
+            $bathsFull  = $l->property->bathsFull;
+            $bathsTotal = $l->property->bathrooms;
+
+            $baths = 0;
+            if (is_numeric($bathsTotal)) {
+                $baths = $bathsTotal + 0; // Strips extraneous decimals
+            } else {
+                $baths = $bathsFull;
+            }
+
+            var_dump($baths);
 
             /**
              * Show listing brokerage, if applicable

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.1
+Version: 2.3.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Ref #49 

---

The [sr_listings] short-code was recently updated to provide better
logic for determing the best field/data to show for the 'bathrooms'
field. This updates the [sr_listings_slider] to use the same logic.

Basically, the 'bathrooms' field is checked first, and if it's
available (and numeric) that is used for the 'baths' number. If that's
not available, 'bathsFull' is used - which is the current behavior.

---

- [x] Improve display logic for `baths` in [sr_listings_slider]
- [x] Bump minor version