### PR TITLE
Add option to show Agent/Office above the fold

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
+    - 5.6
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.3
+* FEATURE: Add compliance option for showing agent/office above the fold on single listing pages
+
 ## 2.3.2
 * FEATURE: Prioritize bathrooms over bathsFull in [sr_listings_slider]
 * UPDATE: Update compatibility with latest WordPress version 4.8.1

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.2
+Stable tag: 2.3.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.3 =
+* FEATURE: Add compliance option for showing agent/office above the fold on single listing pages
 
 = 2.3.2 =
 * FEATURE: Prioritize bathrooms over bathsFull in [sr_listings_slider]

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -43,6 +43,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_thumbnail_idx_image');
       register_setting('sr_admin_settings', 'sr_custom_disclaimer');
       register_setting('sr_admin_settings', 'sr_show_mls_status_text');
+      register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
   }
 
   public static function adminMessages () {
@@ -296,6 +297,17 @@ class SrAdminSettings {
                         . checked(1, get_option('sr_office_on_thumbnails'), false) . '/>'
                       ?>
                       Show brokerage name on listing summary thumbnails
+                    </label>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_agent_office_above_the_fold" name="sr_agent_office_above_the_fold" value="1" '
+                        . checked(1, get_option('sr_agent_office_above_the_fold'), false) . '/>'
+                      ?>
+                      Show Listing Agent and Office above the fold on single listing pages
                     </label>
                   </td>
                 </tr>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -937,6 +937,22 @@ HTML;
         $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office);
 
 
+        /**
+         * Show "Listing by" if sr_agent_office_above_the_fold is
+         * enabled
+         */
+        $hasAgentOfficeData = !empty($office) AND !empty($listing_agent_name);
+        if (get_option('sr_agent_office_above_the_fold') && $hasAgentOfficeData) {
+            $listing_by = 'Listing by: '
+                        . "<strong>$listing_agent_name</strong>"
+                        . ', '
+                        . "<strong>$office</strong>";
+            $listing_by_markup = "<p>$listing_by</p>";
+        } else {
+            $listing_by = '';
+        }
+
+
         $galleria_theme = plugins_url('assets/galleria/themes/classic/galleria.classic.min.js', __FILE__);
 
         // Build details link for map marker
@@ -1001,6 +1017,7 @@ HTML;
         // listing markup
         $cont .= <<<HTML
           <div class="sr-details" style="text-align:left;">
+            $listing_by_markup
             <p class="sr-details-links" style="clear:both;">
               $mapLink
               $more_photos

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -934,23 +934,19 @@ HTML;
         }
 
 
+        /**
+         * Create the custom compliance markup
+         */
         $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office);
 
 
         /**
-         * Show "Listing by" if sr_agent_office_above_the_fold is
-         * enabled
+         * Create the "Listing by" markup
          */
-        $hasAgentOfficeData = !empty($office) AND !empty($listing_agent_name);
-        if (get_option('sr_agent_office_above_the_fold') && $hasAgentOfficeData) {
-            $listing_by = 'Listing by: '
-                        . "<strong>$listing_agent_name</strong>"
-                        . ', '
-                        . "<strong>$office</strong>";
-            $listing_by_markup = "<p>$listing_by</p>";
-        } else {
-            $listing_by = '';
-        }
+        $listing_by_markup = SrUtils::mkAgentOfficeAboveTheFold(
+            $listing_agent_name,
+            $listing_office
+        );
 
 
         $galleria_theme = plugins_url('assets/galleria/themes/classic/galleria.classic.min.js', __FILE__);
@@ -1670,8 +1666,6 @@ HTML;
             } else {
                 $baths = $bathsFull;
             }
-
-            var_dump($baths);
 
             /**
              * Show listing brokerage, if applicable

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -52,6 +52,7 @@ class SimplyRetsCustomPostPages {
 
         add_option('sr_office_on_thumbnails', false);
         add_option('sr_thumbnail_idx_image', '');
+        add_option('sr_agent_office_above_the_fold', false);
 
         flush_rewrite_rules();
     }

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -233,6 +233,65 @@ class SrUtils {
         }
     }
 
+    /**
+     * Created the "Listing by" markup if
+     * sr_agent_office_above_the_fold is enabled. This also handles
+     * showing the correct info when only the agent name, or only the
+     * office name is available.
+     */
+    public static function mkAgentOfficeAboveTheFold($agent, $office) {
+
+        // Initialize variables
+        $listing_by;
+        $listing_by_markup;
+
+        // Ensure we have all the info we need
+        $agentOfficeAboveTheFoldEnabled = get_option(
+            'sr_agent_office_above_the_fold',
+            false
+        );
+
+        if ($agentOfficeAboveTheFoldEnabled) {
+
+            if (!empty($agent) AND !empty($office)) {
+
+                /**
+                 * Agent and office are available, show both of them
+                 */
+                $listing_by .= "Listing by: ";
+                $listing_by .= "<strong>$agent</strong>, ";
+                $listing_by .= "<strong>$office</strong>";
+                $listing_by_markup = "<p>$listing_by</p>";
+
+            } elseif (empty($agent) AND !empty($office)) {
+
+                /**
+                 * Only office name is available, show that
+                 */
+                $listing_by = "Listing by: <strong>$office</strong>";
+                $listing_by_markup = "<p>$listing_by</p>";
+
+            } elseif (!empty($agent) AND empty($office)) {
+
+                /**
+                 * Only agent name is available, show that
+                 */
+                $listing_by = "Listing by: <strong>$agent</strong>";
+                $listing_by_markup = "<p>$listing_by</p>";
+
+            } else {
+
+                /**
+                 * No agen or office available, don't show anything
+                 */
+                $listing_by = "";
+                $listing_by_markup = "";
+            }
+        }
+
+        return $listing_by_markup;
+    }
+
 }
 
 

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.2
+Version: 2.3.3
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This is a new IDX compliance setting that can be enabled to show Listing
Agent and Listing Office information above-the-fold on single listing
details pages.

This is a requirement and some MLSs, and this option can be enabled to
meet those requirements. The option is not enabled by default, and
normally the Listing Agent/Office is shown in the information table with
the other data.

- [x] Add option to admin compliance section
- [ ] Implement markup based on admin setting
  - Do we need to check the other settings too, like "Hide agent/office
    contact information"?