### PR TITLE
Fix Google Maps error in client side sr_map_search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.4
+* FIX: Fix critical Google maps error in [sr_map_search] short-code
+
 ## 2.3.3
 * FEATURE: Add compliance option for showing agent/office above the fold on single listing pages
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -289,7 +289,7 @@ var getSearchFormValues = function() {
 
 
 /**
- * Our Map Class
+ * Our SimplyRETSMap Class
  * Holds some state for working with the map:
  */
 function SimplyRETSMap() {

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -292,7 +292,7 @@ var getSearchFormValues = function() {
  * Our Map Class
  * Holds some state for working with the map:
  */
-function Map() {
+function SimplyRETSMap() {
 
     this.element    = 'sr-map-search';
     this.bounds     = [];
@@ -324,12 +324,12 @@ function Map() {
 
 
 /**
- * Map prototype methods
+ * SimplyRETSMap prototype methods
  */
 
 
 /** `rec`: google.maps.OverlayType === RECTANGLE */
-Map.prototype.getRectanglePoints = function(rec) {
+SimplyRETSMap.prototype.getRectanglePoints = function(rec) {
 
     var latLngs = [];
     var bounds  = new google.maps.LatLngBounds();
@@ -354,7 +354,7 @@ Map.prototype.getRectanglePoints = function(rec) {
     return latLngs;
 }
 
-Map.prototype.getPolygonPoints = function(polygon) {
+SimplyRETSMap.prototype.getPolygonPoints = function(polygon) {
 
     var paths  = polygon.getPaths();
     var points = [];
@@ -394,30 +394,30 @@ Map.prototype.getPolygonPoints = function(polygon) {
 }
 
 
-Map.prototype.addEventListener = function(source, event, fn) {
+SimplyRETSMap.prototype.addEventListener = function(source, event, fn) {
     return google.maps.event.addListener(source, event, fn);
 }
 
-Map.prototype.searchFormValues = function() {
+SimplyRETSMap.prototype.searchFormValues = function() {
     return getSearchFormValues();
 };
 
-Map.prototype.clearMarkers = function() {
+SimplyRETSMap.prototype.clearMarkers = function() {
     if(this.markers.length > 0)
         this.setMapOnMarkers(null);
 }
 
-Map.prototype.clearPolygon = function() {
+SimplyRETSMap.prototype.clearPolygon = function() {
     if(this.polygon !== null)
         this.setMapOnPolygon(null);
 }
 
-Map.prototype.setDrawCtrlOptions = function(opts) {
+SimplyRETSMap.prototype.setDrawCtrlOptions = function(opts) {
     return this.drawCtrl.setOptions(opts);
 }
 
 
-Map.prototype.handlePolygonDraw = function(that, overlay) {
+SimplyRETSMap.prototype.handlePolygonDraw = function(that, overlay) {
 
     that.clearMarkers();
     that.clearPolygon();
@@ -437,7 +437,7 @@ Map.prototype.handlePolygonDraw = function(that, overlay) {
 }
 
 
-Map.prototype.handleRectangleDraw = function(that, overlay) {
+SimplyRETSMap.prototype.handleRectangleDraw = function(that, overlay) {
 
     that.clearMarkers();
     that.clearPolygon();
@@ -457,7 +457,7 @@ Map.prototype.handleRectangleDraw = function(that, overlay) {
 }
 
 
-Map.prototype.handleFormSubmit = function(e) {
+SimplyRETSMap.prototype.handleFormSubmit = function(e) {
     e.preventDefault();
 
     this.clearMarkers();
@@ -475,7 +475,7 @@ Map.prototype.handleFormSubmit = function(e) {
 }
 
 
-Map.prototype.setMapOnMarkers = function(map) {
+SimplyRETSMap.prototype.setMapOnMarkers = function(map) {
 
     for(var i = 0; i < this.markers.length; i++) {
         this.markers[i].setMap(map);
@@ -485,7 +485,7 @@ Map.prototype.setMapOnMarkers = function(map) {
 }
 
 
-Map.prototype.setMapOnPolygon = function(map) {
+SimplyRETSMap.prototype.setMapOnPolygon = function(map) {
 
     this.polygon.setMap(map);
 
@@ -493,7 +493,7 @@ Map.prototype.setMapOnPolygon = function(map) {
 }
 
 
-Map.prototype.handleRequest = function(that, data) {
+SimplyRETSMap.prototype.handleRequest = function(that, data) {
 
     // Remove data from map before request
     that.setMapOnMarkers(null);
@@ -542,7 +542,7 @@ Map.prototype.handleRequest = function(that, data) {
 
 }
 
-Map.prototype.initPaginationEventHandlers = function(that, pag) {
+SimplyRETSMap.prototype.initPaginationEventHandlers = function(that, pag) {
 
     if(pag.next !== null) {
 
@@ -581,7 +581,7 @@ Map.prototype.initPaginationEventHandlers = function(that, pag) {
 }
 
 
-Map.prototype.setLoadMsgMap = function(map) {
+SimplyRETSMap.prototype.setLoadMsgMap = function(map) {
 
     if(!this.polygon && !this.rectangle) return;
 
@@ -591,7 +591,7 @@ Map.prototype.setLoadMsgMap = function(map) {
 }
 
 
-Map.prototype.sendRequest = function(points, params, paginate) {
+SimplyRETSMap.prototype.sendRequest = function(points, params, paginate) {
 
     this.setLoadMsgMap(this.map);
 
@@ -640,7 +640,7 @@ Map.prototype.sendRequest = function(points, params, paginate) {
 
 }
 
-Map.prototype.setDrawingManager = function() {
+SimplyRETSMap.prototype.setDrawingManager = function() {
 
     var that = this;
 
@@ -694,7 +694,7 @@ Map.prototype.setDrawingManager = function() {
 };
 
 
-Map.prototype.initEventListeners = function() {
+SimplyRETSMap.prototype.initEventListeners = function() {
 
     var that = this;
 
@@ -728,7 +728,7 @@ Map.prototype.initEventListeners = function() {
 
 var startMap = function() {
 
-    var map = new Map();
+    var map = new SimplyRETSMap();
     map.setDrawingManager();
     map.initEventListeners();
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.3
+Stable tag: 2.3.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.4 =
+* FIX: Fix critical Google maps error in [sr_map_search] short-code
 
 = 2.3.3 =
 * FEATURE: Add compliance option for showing agent/office above the fold on single listing pages

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.3
+Version: 2.3.4
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
**BUGFIX**

This fixes a new error in the client side JavaScript that uses the
Google Maps API. Google recently updated the Maps API so that the
function "Map" cannot be redefined. This was the name we used for our
client-side map function, and the new Google update makes this breaks
and causes maps not be shown.

The fix is to simply rename our Map function to SimplyRETSMap, which is
more unique and shouldn't have any issues with conflicting code.