### PR TITLE
Add admin option to show MLS trademark symbol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.5
+* FEATURE: Add admin compliance option to show trademark symbol next to "MLS" text.
+
 ## 2.3.4
 * FIX: Fix critical Google maps error in [sr_map_search] short-code
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -101,9 +101,10 @@ var buildUglyLink = function(mlsId, address, root) {
 }
 
 
-var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText) {
+var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText, mlsTrademark) {
 
     var stat  = statusText ? listing.mls.statusText : listing.mls.status;
+    var mlsText = Boolean(mlsTrademark) ? "MLS®" : "MLS"
     var baths = listing.property.bathsFull || "n/a";
     var beds  = listing.property.bedrooms  || "n/a";
     var style = listing.property.style     || "Res" ;
@@ -137,7 +138,7 @@ var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThum
        '  <hr>' +
        '  <div class="sr-iw-inner__secondary">' +
        '    <p><strong>Price: </strong>$' + price + '</p>' +
-       '    <p><strong>MLS #: </strong>' + mlnum + '</p>' +
+       '    <p><strong>' + mlsText + ' #: </strong>' + mlnum + '</p>' +
        '    <p><strong>Area: </strong>' + sqft + '</p>' +
        '    <p><strong>Property Type: </strong>' + type + '</p>' +
        '    <p><strong>Property Style: </strong>' + style + '</p>' +
@@ -155,7 +156,7 @@ var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThum
 }
 
 
-var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText) {
+var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText, mlsTrademark) {
     // if(!listings || listings.length < 1) return [];
 
     var markers = [];
@@ -170,7 +171,7 @@ var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, office
 
             var bound  = new google.maps.LatLng(listing.geo.lat, listing.geo.lng);
 
-            var popup  = genMarkerPopup(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText);
+            var popup  = genMarkerPopup(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText, mlsTrademark);
 
             var window = new google.maps.InfoWindow({
                 content: popup
@@ -507,6 +508,7 @@ SimplyRETSMap.prototype.handleRequest = function(that, data) {
     var officeOnThumbnails = document.getElementById('sr-map-search').dataset.officeOnThumbnails;
     var linkStyle = data.permalink_structure === "" ? "default" : "pretty";
     var statusText = data.show_mls_status_text;
+    var mlsTrademark = data.show_mls_trademark_symbol;
 
     that.siteRoot = data.site_root
     that.linkStyle = linkStyle;
@@ -520,7 +522,8 @@ SimplyRETSMap.prototype.handleRequest = function(that, data) {
                                 , that.siteRoot
                                 , idxImg
                                 , officeOnThumbnails
-                                , statusText );
+                                , statusText
+                                , mlsTrademark );
 
     that.bounds   = markers.bounds;
     that.markers  = markers.markers;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.4
+Stable tag: 2.3.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.5 =
+* FEATURE: Add admin compliance option to show trademark symbol next to "MLS" text.
 
 = 2.3.4 =
 * FIX: Fix critical Google maps error in [sr_map_search] short-code

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -44,6 +44,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_custom_disclaimer');
       register_setting('sr_admin_settings', 'sr_show_mls_status_text');
       register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
+      register_setting('sr_admin_settings', 'sr_show_mls_trademark_symbol');
   }
 
   public static function adminMessages () {
@@ -321,6 +322,22 @@ class SrAdminSettings {
                           name="sr_thumbnail_idx_image"
                           value="<?php echo esc_attr( get_option('sr_thumbnail_idx_image') ); ?>"
                       />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <h3>MLS trademark symbol</h3>
+            <table>
+              <tbody>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_show_mls_trademark_symbol" name="sr_show_mls_trademark_symbol" value="1" '
+                        . checked(1, get_option('sr_show_mls_trademark_symbol'), false) . '/>'
+                      ?>
+                        Show trademark symbol next to MLS text (eg, "MLS®")
+                    </label>
                   </td>
                 </tr>
               </tbody>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1131,7 +1131,7 @@ HTML;
               $school_data
               <thead>
                 <tr>
-                  <th colspan="3"><h5>Mls Information</h5></th></tr></thead>
+                  <th colspan="3"><h5>$MLS_text Information</h5></th></tr></thead>
               <tbody>
                 $days_on_market
                 $mls_status

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -521,6 +521,9 @@ HTML;
         // internal unique id
         $listing_uid = $listing->mlsId;
 
+        // Get the text "MLS"
+        $MLS_text = SrUtils::mkMLSText();
+
         /**
          * Get the listing status to show. Note that if the
          * sr_show_mls_status_text admin option is set to true, we
@@ -528,7 +531,7 @@ HTML;
          * status.
          */
         $listing_mls_status = SrListing::listingStatus($listing);
-        $mls_status = SimplyRetsApiHelper::srDetailsTable($listing_mls_status, "MLS Status");
+        $mls_status = SimplyRetsApiHelper::srDetailsTable($listing_mls_status, $MLS_text . " Status");
 
         // price
         $listing_price = $listing->listPrice;
@@ -572,7 +575,7 @@ HTML;
         $geo_market_area = SimplyRetsApiHelper::srDetailsTable($listing_market_area, "Market Area");
         // mls area
         $listing_mlsarea = $listing->mls->area;
-        $mls_area = SimplyRetsApiHelper::srDetailsTable($listing_mlsarea, "MLS Area");
+        $mls_area = SimplyRetsApiHelper::srDetailsTable($listing_mlsarea, $MLS_text . " Area");
         // tax data
         $listing_taxdata = $listing->tax->id;
         $tax_data = SimplyRetsApiHelper::srDetailsTable($listing_taxdata, "Tax ID");
@@ -605,7 +608,7 @@ HTML;
         $yearBuilt = SimplyRetsApiHelper::srDetailsTable($listing_yearBuilt, "Year Built");
         // listing id (MLS #)
         $listing_mlsid = $listing->listingId;
-        $mlsid = SimplyRetsApiHelper::srDetailsTable($listing_mlsid, "MLS #");
+        $mlsid = SimplyRetsApiHelper::srDetailsTable($listing_mlsid, $MLS_text . " #");
         // heating
         $listing_heating = $listing->property->heating;
         $heating = SimplyRetsApiHelper::srDetailsTable($listing_heating, "Heating");
@@ -858,7 +861,7 @@ HTML;
 
         if( get_option('sr_show_leadcapture') ) {
             $contact_text = 'Contact us about this listing';
-            $cf_listing = $listing_address . ' ( MLS #' . $listing_mlsid . ' )';
+            $cf_listing = $listing_address . ' ( ' . $MLS_text . ' #' . $listing_mlsid . ' )';
             $contact_markup = SimplyRetsApiHelper::srContactFormMarkup($cf_listing);
         } else {
             $contact_text = '';
@@ -1186,6 +1189,8 @@ HTML;
         $vendor       = isset($settings['vendor'])   ? $settings['vendor']   : '';
         $map_setting  = isset($settings['show_map']) ? $settings['show_map'] : '';
 
+        $MLS_text = SrUtils::mkMLSText();
+
         /** Allow override of "map_position" admin setting on a per short-code basis */
         $map_position = isset($settings['map_position']) ? $settings['map_position'] : $map_position;
 
@@ -1323,7 +1328,7 @@ HTML;
             );
             $yearMarkup  = SimplyRetsApiHelper::resultDataColumnMarkup($yearBuilt, 'Built in', true);
             $cityMarkup  = SimplyRetsApiHelper::resultDataColumnMarkup($city, 'Located in', true);
-            $mlsidMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($mlsid, 'MLS #:', true);
+            $mlsidMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($mlsid, $MLS_text . ' #:', true);
 
             if( $area == 0 ) {
                 $areaMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($bathsHalf, 'Half Baths', false);

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -135,6 +135,7 @@ HTML;
 
             $permalink_struct = get_option('permalink_structure');
             $showStatusText = get_option('sr_show_mls_status_text', false);
+            $showMlsTrademark = get_option('sr_show_mls_trademark_symbol', false);
             $site_root = get_site_url();
 
             header("Content-Type: application/json");
@@ -152,6 +153,7 @@ HTML;
                 "post"   => $_POST,
                 "permalink_structure" => $permalink_struct,
                 "show_mls_status_text" => $showStatusText,
+                "show_mls_trademark_symbol" => $showMlsTrademark,
                 "site_root" => $site_root
             );
 

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -84,6 +84,9 @@ class SrSearchMap {
         $style,
         $compliance_markup
     ) {
+
+        $MLS_text = SrUtils::mkMLSText();
+
         $markup = <<<HTML
             <div class="sr-iw-inner">
               <h4 class="sr-iw-addr">$address<small> $price</small></h4>
@@ -97,7 +100,7 @@ class SrSearchMap {
               </div>
               <hr>
               <div class="sr-iw-inner__secondary">
-                <p><strong>MLS #:</strong> $mlsid</p>
+                <p><strong>$MLS_text #:</strong> $mlsid</p>
                 <p><strong>Area:</strong> $area SqFt</p>
                 <p><strong>Property Type:</strong> $propType</p>
                 <p><strong>Property Style:</strong> $style</p>

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -53,6 +53,7 @@ class SimplyRetsCustomPostPages {
         add_option('sr_office_on_thumbnails', false);
         add_option('sr_thumbnail_idx_image', '');
         add_option('sr_agent_office_above_the_fold', false);
+        add_option('sr_show_mls_trademark_symbol', false);
 
         flush_rewrite_rules();
     }

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -61,6 +61,8 @@ class SrShortcodes {
                      ? "<div class=\"sr-map-search-list-view\"></div>"
                      : "";
 
+        $MLS_text = SrUtils::mkMLSText();
+
         if(!empty($atts['search_form'])) {
 
             $single_vendor = SrUtils::isSingleVendor();
@@ -91,7 +93,7 @@ class SrShortcodes {
                         <div class="sr-search-field" id="sr-search-keywords">
                           <input name="sr_keywords"
                                  type="text"
-                                 placeholder="Subdivision, Zipcode, MLS Area, MLS Number, or Market Area"
+                                 placeholder="Subdivision, Zipcode, $MLS_text Area, $MLS_text Number, or Market Area"
                           />
                         </div>
 
@@ -354,6 +356,7 @@ HTML;
         ob_start();
         $home_url = get_home_url();
         $singleVendor = SrUtils::isSingleVendor();
+        $MLS_text = SrUtils::mkMLSText();
 
         if( !is_array($atts) ) {
             $atts = array();
@@ -509,7 +512,7 @@ HTML;
                       <div class="sr-search-field" id="sr-search-keywords">
                         <input name="sr_keywords"
                                type="text"
-                               placeholder="Subdivision, Zipcode, MLS Area, MLS Number, or Market Area"
+                               placeholder="Subdivision, Zipcode, <?php echo $MLS_text ?> Area, <?php echo $MLS_text ?> Number, or Market Area"
                                value="<?php echo $keywords ?>" />
                       </div>
 
@@ -641,7 +644,7 @@ HTML;
               <div class="sr-search-field" id="sr-search-keywords">
                 <input name="sr_keywords"
                        type="text"
-                       placeholder="Subdivision, Zipcode, MLS Area, MLS Number, or Market Area"
+                       placeholder="Subdivision, Zipcode, <?php echo $MLS_text ?> Area, <?php echo $MLS_text ?> Number, or Market Area"
                        value="<?php echo $keywords ?>" />
               </div>
 

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -292,6 +292,21 @@ class SrUtils {
         return $listing_by_markup;
     }
 
+    /**
+     * Return the text "MLS". If the 'sr_show_mls_trademark_symbol'
+     * admin option is enabled, the trademark symbol is returned with
+     * the text: MLS®
+     */
+    public static function mkMLSText() {
+        $td = get_option('sr_show_mls_trademark_symbol', false);
+
+        if (empty($td)) {
+            return "MLS";
+        } else {
+            return "MLS®";
+        }
+    }
+
 }
 
 

--- a/simply-rets-widgets.php
+++ b/simply-rets-widgets.php
@@ -43,6 +43,8 @@ class srFeaturedListingWidget extends WP_Widget {
     /** admin widget form --  @see WP_Widget::form */
     function form( $instance ) {
         $singleVendor = SrUtils::isSingleVendor();
+        $MLS_text = SrUtils::mkMLSText();
+
         $title  = esc_attr($instance['title']);
         $mlsid  = esc_attr($instance['mlsid']);
         $vendor = esc_attr($instance['vendor']);
@@ -61,7 +63,7 @@ class srFeaturedListingWidget extends WP_Widget {
 
         <p>
             <label for="<?php echo $this->get_field_id('mlsid'); ?>">
-                <?php _e('Listing MLS Id:'); ?>
+                <?php _e('Listing ' . $MLS_text . ' Id:'); ?>
             </label>
             <input class="widefat"
                    id="<?php echo $this->get_field_id('mlsid'); ?>"
@@ -138,6 +140,8 @@ class srAgentListingWidget extends WP_Widget {
     /** admin widget form --  @see WP_Widget::form */
     function form( $instance ) {
         $singleVendor = SrUtils::isSingleVendor();
+        $MLS_text = SrUtils::mkMLSText();
+
         $title = esc_attr($instance['title']);
         $agent = esc_attr($instance['agent']);
         $limit = esc_attr($instance['limit']);
@@ -156,7 +160,7 @@ class srAgentListingWidget extends WP_Widget {
 
         <p>
           <label for="<?php echo $this->get_field_id('agent'); ?>">
-                <?php _e('Agent MLS Id:'); ?>
+                <?php _e('Agent ' . $MLS_text . ' Id:'); ?>
           </label>
           <input class="widefat"
                          id="<?php echo $this->get_field_id('agent'); ?>"
@@ -244,6 +248,8 @@ class srRandomListingWidget extends WP_Widget {
     /** admin widget form --  @see WP_Widget::form */
     function form( $instance ) {
         $singleVendor = SrUtils::isSingleVendor();
+        $MLS_text = SrUtils::mkMLSText();
+
         $title  = esc_attr($instance['title']);
         $mlsids = esc_attr($instance['mlsids']);
         $vendor = esc_attr($instance['vendor']);
@@ -262,7 +268,7 @@ class srRandomListingWidget extends WP_Widget {
 
         <p>
             <label for="<?php echo $this->get_field_id('mlsids'); ?>">
-                <?php _e('MLS Id\'s (comma separated):'); ?>
+                <?php _e($MLS_text . ' Id\'s (comma separated):'); ?>
             </label>
             <input class="widefat"
                    id="<?php echo $this->get_field_id('mlsids'); ?>"

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.4
+Version: 2.3.5
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This adds an admin Compliance Settings option that, when enabled, shows
the circle R trademark symbol wherever the text "MLS" is shown. Eg:

Enabled: MLS®
Disabled: MLS

This mostly only needs to be used in Canada where "MLS" is a registered
trademark. For USA MLS companies, this generally does not need to be
enabled, so we're making it an option that is disabled by default.