### PR TITLE
Support searching with multiple `q` parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.6
+* FEATURE: Add support for multiple values in the `q` parameter.
+
 ## 2.3.5
 * FEATURE: Add admin compliance option to show trademark symbol next to "MLS" text.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.5
+Stable tag: 2.3.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.6 =
+* FEATURE: Add support for multiple values in the `q` parameter.
 
 = 2.3.5 =
 * FEATURE: Add admin compliance option to show trademark symbol next to "MLS" text.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -741,58 +741,52 @@ class SimplyRetsCustomPostPages {
                 "map_position" => $map_position
             );
 
-            foreach( $listing_params as $param => $val ) {
-                if( !$val == '' ) {
-                    $filters_string .= ' ' . $param . '=\'' . $val . '\'';
+
+            /**
+             * The next two blocks create a string of attributes that
+             * will be added to the (dynamically injected)
+             * sr_search_form short-code on the new page. This is so,
+             * if a user is viewing results and goes to the "next"
+             * page, the search form values stay in tact.
+             */
+
+            // Combine sr_q and _keywords into 1 string.
+            $kw_string = implode(
+                "; ",
+                get_query_var('sr_q', array()) + array(get_query_var('sr_keywords', ''))
+            );
+
+            $filters_string = '';
+            $next_atts = $listing_params + array(
+                "q" => $kw_string,
+                "advanced" => $advanced == "true" ? "true" : "false"
+            );
+
+            foreach( $next_atts as $param => $att ) {
+                if( !$att == '' ) {
+                    $filters_string .= ' ' . $param . '=\'' . $att . '\'';
                 }
             }
 
-            /**
-             * Make advanced search page with new query
-             */
-            if( !$advanced || !$advanced == "true" ) {
-              $qs = '?'
-                  . http_build_query( array_filter( $listing_params ) )
-                  . $features_string
-                  . $cities_string
-                  . $counties_string
-                  . $neighborhoods_string
-                  . $agents_string
-                  . $ptypes_string
-                  . $statuses_string
-                  . $amenities_string
-                  . $q_string;
 
-              $qs = str_replace(' ', '%20', $qs);
-              $listings_content = SimplyRetsApiHelper::retrieveRetsListings($qs, $settings);
-              $content .= do_shortcode( "[sr_search_form  $filters_string]");
-              $content .= $listings_content;
-              return $content;
+            // Final API query string
+            $qs = '?'
+                . http_build_query( array_filter( $listing_params ) )
+                . $features_string
+                . $cities_string
+                . $counties_string
+                . $neighborhoods_string
+                . $agents_string
+                . $ptypes_string
+                . $statuses_string
+                . $amenities_string
+                . $q_string;
 
-            /**
-             * Make regular search page with new query
-             */
-            } else {
+            $qs = str_replace(' ', '%20', $qs);
 
-              $qs = '?';
-              $qs .= http_build_query( array_filter( $listing_params ) );
-              $qs .= $features_string;
-              $qs .= $cities_string;
-              $qs .= $counties_string;
-              $qs .= $agents_string;
-              $qs .= $ptypes_string;
-              $qs .= $neighborhoods_string;
-              $qs .= $statuses_string;
-              $qs .= $amenities_string;
-              $qs .= $q_string;
-
-              $qs = str_replace(' ', '%20', $qs);
-              $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $qs );
-
-              $content .= do_shortcode( "[sr_search_form  advanced='True' $filters_string]");
-              $content .= $listings_content;
-              return $content;
-            }
+            $listings_content = SimplyRetsApiHelper::retrieveRetsListings($qs, $settings);
+            $content .= do_shortcode( "[sr_search_form  $filters_string]");
+            $content .= $listings_content;
 
             return $content;
         }

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -211,6 +211,7 @@ HTML;
             && !isset($listing_params['agent'])
             && !isset($listing_params['type'])
             && !isset($listing_params['status'])
+            && !isset($listing_params['q'])
         )
         {
             $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $listing_params, $atts );
@@ -274,6 +275,15 @@ HTML;
                 $counties_string = str_replace(' ', '%20', $counties_string );
             }
 
+            if( isset( $listing_params['q'] ) && !empty( $listing_params['q'] ) ) {
+                $keywords = explode( ';', $listing_params['q'] );
+                foreach( $keywords as $key => $keyword ) {
+                    $kw = trim($keyword);
+                    $q_string .= "q=$kw&";
+                }
+                $q_string = str_replace(' ', '%20', $q_string );
+            }
+
             /**
              * Multiple statuses
              */
@@ -301,6 +311,7 @@ HTML;
                     && $key !== 'agent'
                     && $key !== 'type'
                     && $key !== 'status'
+                    && $key !== 'q'
                 ) {
                     $params_string .= $key . "=" . $value . "&";
                 }
@@ -318,6 +329,7 @@ HTML;
             $qs .= $agents_string;
             $qs .= $ptypes_string;
             $qs .= $statuses_string;
+            $qs .= $q_string;
 
             $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $qs, $atts );
             return $listings_content;

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.5
+Version: 2.3.6
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
The SimplyRETS API recently added support for setting multiple `q` parameters in a query. This PR updates the plugin to support that as well.

Supporting multiple `q` parameters is two-fold:

- [x] Support `;` delimiter in `q` parameter from `[sr_listings q="1; 2; 3"]` short-code
- [x] Support `;` delimiter in `q` parameterwhen parsing `[sr_search_form q="1; 2; 3"]`
  - **NOTE**: This also means that a user can use a semi-colon from the client-side search form to set multiple values.
- [x] Bumb version number