### PR TITLE
Fix markup in sr_map_search search form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.7
+* BUGFIX: Fix invalid markup in [sr_map_search] short-code search form.
+
 ## 2.3.6
 * FEATURE: Add support for multiple values in the `q` parameter.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.6
+Stable tag: 2.3.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.7 =
+* BUGFIX: Fix invalid markup in `[sr_map_search]` short-code search form.
 
 = 2.3.6 =
 * FEATURE: Add support for multiple values in the `q` parameter.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.6 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.7 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.6 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.7 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -100,7 +100,7 @@ class SrShortcodes {
                         <div class="sr-search-field" id="sr-search-ptype">
                           <select name="sr_ptype">
                             <option value="">Property Type</option>
-                            <?php echo $type_options; ?>
+                            $type_options;
                           </select>
                         </div>
                       </div>
@@ -128,10 +128,10 @@ class SrShortcodes {
                         </div>
                       </div>
 
-                      <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
-                      <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
-                      <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
-                      <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
+                      <input type="hidden" name="sr_vendor"  value="$vendor" />
+                      <input type="hidden" name="sr_brokers" value="$brokers" />
+                      <input type="hidden" name="sr_agent"   value="$agent" />
+                      <input type="hidden" name="limit"      value="$limit" />
 
                       <div>
                           <input class="submit button btn" type="submit" value="Search Properties">

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.6
+Version: 2.3.7
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
The function to generate the markup was incorrectly using `echo` inside
of an HTML Heredoc string, which is invalid. This diff removes the echo
and just calls the variable directly (`$var`).