### PR TITLE
Support "status" attribute on [sr_search_form] short-code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.8
+* FEATURE: Add support for "status" attribute on [sr_search_form] (non-advanced version only).
+
 ## 2.3.7
 * BUGFIX: Fix invalid markup in [sr_map_search] short-code search form.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.7
+Stable tag: 2.3.8
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.8 =
+* FEATURE: Add support for "status" attribute on [sr_search_form] (non-advanced version only).
 
 = 2.3.7 =
 * BUGFIX: Fix invalid markup in `[sr_map_search]` short-code search form.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.7 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.8 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.7 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.8 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -594,6 +594,7 @@ class SimplyRetsCustomPostPages {
              */
             $statuses = isset($_GET['sr_status']) ? $_GET['sr_status'] : $status;
             $statuses_string = '';
+            $statuses_attribute = '';
 
             if(!is_array($statuses) && !empty($statuses)) {
                 if(strpos($statuses, ";") !== FALSE) {
@@ -601,14 +602,18 @@ class SimplyRetsCustomPostPages {
                 } else {
                     $statuses_string = "&status=$statuses";
                 }
+
+                $statuses_attribute = $statuses;
             }
+
             if(is_array($statuses) && !empty($statuses)) {
                 foreach((array)$statuses as $key => $stat) {
                     $final = trim($stat);
                     $statuses_string .= "&status=$final";
                 }
-            }
 
+                $statuses_attribute = implode(";", $statuses);
+            }
 
             /**
              * The loops below check if the short-code has multiple
@@ -756,12 +761,15 @@ class SimplyRetsCustomPostPages {
                 get_query_var('sr_q', array()) + array(get_query_var('sr_keywords', ''))
             );
 
-            $filters_string = '';
             $next_atts = $listing_params + array(
                 "q" => $kw_string,
+                "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false"
             );
 
+            // Create a string of attributes to put on the
+            // [sr_search_form] short-code.
+            $filters_string = '';
             foreach( $next_atts as $param => $att ) {
                 if( !$att == '' ) {
                     $filters_string .= ' ' . $param . '=\'' . $att . '\'';

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -691,11 +691,6 @@ HTML;
               </div>
             </div>
 
-            <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
-            <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
-            <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
-            <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
-
             <div>
                 <input class="submit button btn" type="submit" value="Search Properties">
 
@@ -709,6 +704,12 @@ HTML;
                     </select>
                 </div>
             </div>
+
+            <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
+            <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
+            <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
+            <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
+            <input type="hidden" name="status"     value="<?php echo $adv_status; ?>" />
 
           </form>
         </div>

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.7
+Version: 2.3.8
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This adds support for setting a "status" attribute on the
[sr_search_form] short-code so that a form can be configured for
searching specific statuses instead of the default.

NOTE: If the advanced attribute is set to true on [sr_search_form], the
status attribute already works. This adds functionality for the
non-advanced version of the search form.

Usage: [sr_search_form status="ActiveUnderContract"]

**Tasks**

- [x] Support "status" attribute on non-advanced [sr_search_form]
- [x] Retain search form status in next/prev pagination links
- [x] Retain status filter on page 2+ of a search (similar issues in the
  past, just noting it so it can be tested).
- [x] Support specifying multiple statuses separated by ";" (NOTE: the
  advanced version of the search form only supports 1 status).
- [x] Advanced search form functionality is the same