### PR TITLE
Add support for setting initial points on [sr_map_search]

### DIFF
--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -703,8 +703,12 @@ SimplyRETSMap.prototype.initEventListeners = function() {
 
     // fetch initial listings when map is loaded
     this.addEventListener(this.map, 'idle', function() {
+
+        var initPoints = getInitialPoints()
+        var points = initPoints ? initPoints : []
+
         if(!that.loaded) {
-            that.sendRequest([], {}).done(function(data) {
+            that.sendRequest(points, {}).done(function(data) {
                 that.handleRequest(that, data);
                 that.loaded = true;
             });
@@ -727,6 +731,35 @@ SimplyRETSMap.prototype.initEventListeners = function() {
     return;
 
 };
+
+/*
+ * If the user set the `pointsQuery` attribute on the [sr_map_search]
+ * short-code, then get and parse those points to be passed into the
+ * intial query for loading listings. This is for use-cases where the
+ * user wants to show a pre-defined area on the map search.
+ */
+function getInitialPoints() {
+    var initPoints = document.getElementById('sr-map-search').dataset.initialPoints;
+
+    if (!initPoints) {
+        return null
+    }
+
+    var splitPoints = initPoints.split('&')
+    var ps = []
+
+    for (var idx = 0; idx < splitPoints.length; idx++) {
+        var thisP = splitPoints[idx]
+        var cleaned = thisP.replace('points=', '')
+
+        ps[idx] = {
+            name: 'points',
+            value: cleaned,
+        }
+    }
+
+    return ps
+}
 
 
 var startMap = function() {

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -47,6 +47,16 @@ class SrShortcodes {
         $limit    = isset($atts['limit'])   ? $atts['limit']   : '';
         $type_att = isset($atts['type'])    ? $atts['type'] : '';
 
+        // Allow setting initial "points" on the [sr_map_search]
+        // short-code. This is a bit tricky becausae of the way WP
+        // parses short-code attributes (eg, we can't use characters
+        // like "[" or "]", so the user has to pass in a query string
+        // as if they were calling the API.
+        // This data is set on the `data-initial-points` attribute,
+        // and the client-side code checks for that and sends it with
+        // the initial query for displaying listings.
+        $initial_points = isset($atts['pointsquery']) ? $atts['pointsquery'] : '';
+
         $content     = "";
         $search_form = "";
         $gmaps_key   = get_option('sr_google_api_key', '');
@@ -55,6 +65,7 @@ class SrShortcodes {
         $map_markup  = "<div id='sr-map-search'
                              data-api-key='{$gmaps_key}'
                              data-idx-img='{$idx_img}'
+                             data-initial-points='{$initial_points}'
                              data-office-on-thumbnails='{$office_on_thumbnails}'
                              data-vendor='{$vendor}'></div>";
         $list_markup = !empty($atts['list_view'])


### PR DESCRIPTION
This adds support for a `pointsQuery` attribute on the [sr_map_search]
short-code. This is useful, for example, when a user wants to use the
[sr_map_search] and show listings from a pre-defined area.

Due to the way WP parses short-code attributes, the user must provide a
query-string like value in the `pointsQuery` attribute on the
short-code. That value is then parsed by the client side code and sent
with the initial request when listings are loaded.