### PR TITLE
Show full address in the title on listing details pages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.9
+* FEATURE: Add more address information to single listing page titles for improved indexing.
+
 ## 2.3.8
 * FEATURE: Add support for "status" attribute on [sr_search_form] (non-advanced version only).
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.8.1
-Stable tag: 2.3.8
+Stable tag: 2.3.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.9 =
+* FEATURE: Add more address information to single listing page titles for improved indexing.
 
 = 2.3.8 =
 * FEATURE: Add support for "status" attribute on [sr_search_form] (non-advanced version only).

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.8 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.9 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.8 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.9 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -71,16 +71,23 @@ class SrUtils {
 
         // Listing details
         $listing_id = $listing->mlsId;
+
+        $listing_city = $listing->address->city;
+        $listing_state = $listing->address->state;
+        $listing_zip = $listing->address->postalCode;
         $listing_address = $listing->address->full;
+
+        $listing_address_full = $listing_address
+                              . ', '
+                              . $listing_city
+                              . ', '
+                              . $listing_state
+                              . ' '
+                              . $listing_zip;
 
         if($prettify && $custom_permalink_struct === "pretty_extra") {
 
-            $listing_city = $listing->address->city;
-            $listing_state = $listing->address->state;
-            $listing_zip = $listing->address->postalCode;
-
-
-            $url .= "/listings/$listing_city/$listing_state/$listing_zip/$listing_address/$listing_id";
+            $url .= "/listings/$listing_city/$listing_state/$listing_zip/$listing_address_full/$listing_id";
 
             if(!empty($query)) {
                 $url .= "?" . $query;
@@ -88,7 +95,7 @@ class SrUtils {
 
         } elseif($prettify && $custom_permalink_struct === "pretty") {
 
-            $url .= "/listings/$listing_id/$listing_address";
+            $url .= "/listings/$listing_id/$listing_address_full";
 
             if(!empty($query)) {
                 $url .= "?" . $query;
@@ -98,7 +105,7 @@ class SrUtils {
 
             $url .= "?sr-listings=sr-single"
                  .  "&listing_id=$listing_id"
-                 .  "&listing_title=$listing_address";
+                 .  "&listing_title=$listing_address_full";
 
             if(!empty($query)) {
                 $url .= "&" . $query;
@@ -106,8 +113,10 @@ class SrUtils {
 
         }
 
+        // URL encode special characters
         $url = str_replace(' ', '+', $url);
         $url = str_replace('#', '%23', $url);
+        $url = str_replace(',', '%2C', $url);
 
         return $url;
     }

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.8
+Version: 2.3.9
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Fixes #63 - this updates the single listing details pages to show the
full address including state, zip code, and city in the title area - as
opposed to just the street name and number.

#63 has more details, but this should potentially help clients
with better built-in SEO practices.