### PR TITLE
Add option to show agent name with compliance markup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.10
+* FEATURE: Add compliance option to show agent name on listing summary thumbnails.
+
 ## 2.3.9
 * FEATURE: Add more address information to single listing page titles for improved indexing.
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -101,7 +101,16 @@ var buildUglyLink = function(mlsId, address, root) {
 }
 
 
-var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText, mlsTrademark) {
+var genMarkerPopup = function(
+    listing,
+    linkStyle,
+    siteRoot,
+    idxImg,
+    officeOnThumbnails,
+    agentOnThumbnails,
+    statusText,
+    mlsTrademark
+) {
 
     var stat  = statusText ? listing.mls.statusText : listing.mls.status;
     var mlsText = Boolean(mlsTrademark) ? "MLS®" : "MLS"
@@ -118,6 +127,9 @@ var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThum
               : 'https://s3-us-west-2.amazonaws.com/simplyrets/trial/properties/defprop.jpg';
     var office = officeOnThumbnails && listing.office.name
                ? listing.office.name
+               : ""
+    var agent = agentOnThumbnails && listing.agent.firstName
+               ? listing.agent.firstName + ' ' + listing.agent.lastName
                : ""
 
     var link = linkStyle === "pretty"
@@ -142,7 +154,8 @@ var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThum
        '    <p><strong>Area: </strong>' + sqft + '</p>' +
        '    <p><strong>Property Type: </strong>' + type + '</p>' +
        '    <p><strong>Property Style: </strong>' + style + '</p>' +
-       '    <p><strong>Listing office: </strong>'+ office + '</p>' +
+       (office ? '<p><strong>Listing office: </strong>'+ office + '</p>' : '') +
+       (agent ? '<p><strong>Listing agent: </strong>'+ agent + '</p>' : '') +
        '    <img src="' + idxImg + '"/>' +
        '  </div>' +
        '  <hr>' +
@@ -156,8 +169,17 @@ var genMarkerPopup = function(listing, linkStyle, siteRoot, idxImg, officeOnThum
 }
 
 
-var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText, mlsTrademark) {
-    // if(!listings || listings.length < 1) return [];
+var makeMapMarkers = function(
+    map,
+    listings,
+    linkStyle,
+    siteRoot,
+    idxImg,
+    officeOnThumbnails,
+    agentOnThumbnails,
+    statusText,
+    mlsTrademark
+) {
 
     var markers = [];
     var bounds  = new google.maps.LatLngBounds();
@@ -171,7 +193,16 @@ var makeMapMarkers = function(map, listings, linkStyle, siteRoot, idxImg, office
 
             var bound  = new google.maps.LatLng(listing.geo.lat, listing.geo.lng);
 
-            var popup  = genMarkerPopup(listing, linkStyle, siteRoot, idxImg, officeOnThumbnails, statusText, mlsTrademark);
+            var popup  = genMarkerPopup(
+                listing,
+                linkStyle,
+                siteRoot,
+                idxImg,
+                officeOnThumbnails,
+                agentOnThumbnails,
+                statusText,
+                mlsTrademark
+            );
 
             var window = new google.maps.InfoWindow({
                 content: popup
@@ -506,6 +537,7 @@ SimplyRETSMap.prototype.handleRequest = function(that, data) {
 
     var idxImg = document.getElementById('sr-map-search').dataset.idxImg;
     var officeOnThumbnails = document.getElementById('sr-map-search').dataset.officeOnThumbnails;
+    var agentOnThumbnails = document.getElementById('sr-map-search').dataset.agentOnThumbnails;
     var linkStyle = data.permalink_structure === "" ? "default" : "pretty";
     var statusText = data.show_mls_status_text;
     var mlsTrademark = data.show_mls_trademark_symbol;
@@ -522,6 +554,7 @@ SimplyRETSMap.prototype.handleRequest = function(that, data) {
                                 , that.siteRoot
                                 , idxImg
                                 , officeOnThumbnails
+                                , agentOnThumbnails
                                 , statusText
                                 , mlsTrademark );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.8.1
-Stable tag: 2.3.9
+Tested up to: 4.9.4
+Stable tag: 2.3.10
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 == Changelog ==
 
+= 2.3.10 =
+* FEATURE: Add compliance option to show agent name on listing summary thumbnails.
+
 = 2.3.9 =
 * FEATURE: Add more address information to single listing page titles for improved indexing.
 
@@ -266,45 +269,6 @@ listing sidebar widget.
 = 2.3.0 =
 * FEATURE: Prioritize bathrooms over bathsFull in results list details
 * UPDATE: Update compatibility with latest WordPress version 4.8
-
-= 2.2.6 =
-* FEATURE: Add admin option to use "statusText" API field in place of the standardized status.
-
-= 2.2.5 =
-* FEATURE: Add contact form info (name, email, listing) to the end of the email message body.
-
-= 2.2.4 =
-* BUGFIX: Don't send empty 'status' and 'type' parameters to the API.
-* DOCUMENTATION: Update documentation for 'area' parameter.
-
-= 2.2.3 =
-* DOCUMENTATION: Remove unsupported 'lotsize' parameter from documentation.
-
-= 2.2.2 =
-* FEATURE: Add support for more API fields including Garage Spaces, HOA, and more.
-
-= 2.2.1 =
-* FIX: Fix pagination links when using 'counties' parameter
-
-= 2.2.0 =
-* FEATURE: Add support for showing an IDX image with all listing thumbnails
-* FEATURE: Add support for showing Listing Broker on all listing thumbnails
-* FEATURE: Add support for setting custom disclaimer text.
-* FIX: Don't crop images so watermarks are always shown.
-
-= 2.1.3 =
-* FEATURE: Add support for multiple counties in sr_listings short-code
-
-= 2.1.2 =
-* FIX: Fix missing vendor files
-
-= 2.1.1 =
-* FIX: Check in missing files for maps
-
-= 2.1.0 =
-* FIX: Add admin option for Google Maps API key (which is now required for maps to show on new sites).
-* BUG: Fix 'vendor' parameter initialization in sr_listings_slider short-code
-* BUG: Fix 'vendor' parameter initialization in sr_map_search short-code
 
 **View the complete CHANGELOG:** [here](https://github.com/SimplyRETS/simplyretswp/blog/master/CHANGELOG)
 

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -40,6 +40,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_permalink_structure');
       register_setting('sr_admin_settings', 'sr_google_api_key');
       register_setting('sr_admin_settings', 'sr_office_on_thumbnails');
+      register_setting('sr_admin_settings', 'sr_agent_on_thumbnails');
       register_setting('sr_admin_settings', 'sr_thumbnail_idx_image');
       register_setting('sr_admin_settings', 'sr_custom_disclaimer');
       register_setting('sr_admin_settings', 'sr_show_mls_status_text');
@@ -287,7 +288,7 @@ class SrAdminSettings {
           <hr>
           <div class="sr-admin-settings">
             <h2>Listing Compliance Settings</h2>
-            <h3>Show brokerage name</h3>
+            <h3>Show listing agent and office information</h3>
             <table>
               <tbody>
                 <tr>
@@ -297,7 +298,18 @@ class SrAdminSettings {
                         '<input type="checkbox" id="sr_office_on_thumbnails" name="sr_office_on_thumbnails" value="1" '
                         . checked(1, get_option('sr_office_on_thumbnails'), false) . '/>'
                       ?>
-                      Show brokerage name on listing summary thumbnails
+                      Show listing office name on listing summary thumbnails
+                    </label>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_agent_on_thumbnails" name="sr_agent_on_thumbnails" value="1" '
+                        . checked(1, get_option('sr_agent_on_thumbnails'), false) . '/>'
+                      ?>
+                      Show listing agent name on listing summary thumbnails
                     </label>
                   </td>
                 </tr>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1501,6 +1501,10 @@ HTML;
             $main_photo = $listingPhotos[0];
             $main_photo = str_replace("\\", "", $main_photo);
 
+            // Compliance markup (agent/office)
+            $listing_office  = $listing->office->name;
+            $listing_agent = $listing->agent->firstName . ' ' . $listing->agent->lastName;
+            $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office, $listing_agent);
 
             $vendor = isset($settings['vendor']) ? $settings['vendor'] : '';
             // create link to listing
@@ -1528,6 +1532,9 @@ HTML;
                   <div id="sr-listing-wdgt-remarks">
                     <p>$listing_remarks</p>
                   </div>
+                </div>
+                <div>
+                  <i>$compliance_markup</i>
                 </div>
                 <div id="sr-listing-wdgt-btn">
                   <a href="$link">

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.9 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.10 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.9 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.10 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -940,7 +940,7 @@ HTML;
         /**
          * Create the custom compliance markup
          */
-        $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office);
+        $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office, $listing_agent_name);
 
 
         /**
@@ -1286,7 +1286,7 @@ HTML;
              * Show 'Listing Courtesy of ...' if setting is enabled
              */
             $listing_office = $listing->office->name;
-            $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office);
+            $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office, $listing_agent_name);
 
 
             /************************************************
@@ -1676,7 +1676,8 @@ HTML;
              * Show listing brokerage, if applicable
              */
             $listing_office  = $l->office->name;
-            $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office);
+            $listing_agent = $l->agent->firstName . ' ' . $l->agent->lastName;
+            $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office, $listing_agent);
 
             $inner .= <<<HTML
                 <div class="sr-listing-slider-item">

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -51,6 +51,7 @@ class SimplyRetsCustomPostPages {
         add_option('sr_demo_page_created', false);
 
         add_option('sr_office_on_thumbnails', false);
+        add_option('sr_agent_on_thumbnails', false);
         add_option('sr_thumbnail_idx_image', '');
         add_option('sr_agent_office_above_the_fold', false);
         add_option('sr_show_mls_trademark_symbol', false);

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -52,11 +52,15 @@ class SrShortcodes {
         $gmaps_key   = get_option('sr_google_api_key', '');
         $idx_img     = get_option('sr_thumbnail_idx_image');
         $office_on_thumbnails = get_option('sr_office_on_thumbnails', false);
+        $agent_on_thumbnails = get_option('sr_agent_on_thumbnails', false);
+
         $map_markup  = "<div id='sr-map-search'
                              data-api-key='{$gmaps_key}'
                              data-idx-img='{$idx_img}'
                              data-office-on-thumbnails='{$office_on_thumbnails}'
+                             data-agent-on-thumbnails='{$agent_on_thumbnails}'
                              data-vendor='{$vendor}'></div>";
+
         $list_markup = !empty($atts['list_view'])
                      ? "<div class=\"sr-map-search-list-view\"></div>"
                      : "";

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -201,8 +201,8 @@ class SrUtils {
         $idx_img_on_thumbnails = get_option('sr_thumbnail_idx_image', false);
 
         /** Helpers if agent or office CAN and SHOULD be shown */
-        $show_agent = !empty($agent_on_thumbnails) && !empty($listing_agent);
-        $show_office = !empty($office_on_thumbnails) && !empty($listing_office);
+        $show_agent = !empty($agent_on_thumbnails) && !empty(trim($listing_agent));
+        $show_office = !empty($office_on_thumbnails) && !empty(trim($listing_office));
 
         /** Initial markup */
         $listing_by = "";

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -189,32 +189,63 @@ class SrUtils {
     }
 
 
-    public static function mkListingSummaryCompliance($listing_office) {
+    /**
+     * Create markup for showing various MLS compliance information
+     * based on users current admin settings.
+     */
+    public static function mkListingSummaryCompliance($listing_office, $listing_agent) {
 
+        /** Get current settings */
         $office_on_thumbnails = get_option('sr_office_on_thumbnails', false);
+        $agent_on_thumbnails = get_option('sr_agent_on_thumbnails', false);
         $idx_img_on_thumbnails = get_option('sr_thumbnail_idx_image', false);
 
-        $listing_office_markup  = "";
+        /** Helpers if agent or office CAN and SHOULD be shown */
+        $show_agent = !empty($agent_on_thumbnails) && !empty($listing_agent);
+        $show_office = !empty($office_on_thumbnails) && !empty($listing_office);
+
+        /** Initial markup */
+        $listing_by = "";
         $listing_idx_img_markup = "";
 
-        if (!empty($listing_office) && !empty($office_on_thumbnails)) {
-            $listing_office_markup = "Listing broker: {$listing_office}";
+        /**
+         * Create a "Listing by" string that shows some combination of
+         * listing agent and/or office depending on current settings.
+         */
+        if ($show_office || $show_agent) {
+            $listing_by = "Listing by ";
+
+            if ($show_agent) {
+                $listing_by .= $listing_agent;
+            }
+
+            if ($show_office) {
+                if ($show_agent) {
+                    $listing_by .= ", {$listing_office}";
+                } else {
+                    $listing_by .= $listing_office;
+                }
+            }
         }
 
-        if ($idx_img_on_thumbnails !== false && !empty($idx_img_on_thumbnails)) {
+        /**
+         * Create an <img> element if IDX image is available and
+         * setting is enabled.
+         */
+        if (!empty($idx_img_on_thumbnails) && !empty($idx_img_on_thumbnails)) {
             $listing_idx_img_markup = "<img src=\"{$idx_img_on_thumbnails}\"/>";
         }
 
 
         // Add a line break if both fields are enabled
-        if (!empty($listing_office_markup) && !empty($listing_idx_img_markup)) {
-
-            return "{$listing_office_markup}<br/>{$listing_idx_img_markup}";
-
+        if (!empty($listing_by) && !empty($listing_idx_img_markup)) {
+            return "<span class='sr-listing-summary-compliance'>"
+                . "{$listing_by}<br/>{$listing_idx_img_markup}"
+                . "</span>";
         } else {
-
-            return "{$listing_office_markup} {$listing_idx_img_markup}";
-
+            return "<span class='sr-listing-summary-compliance'>"
+                . "{$listing_by} {$listing_idx_img_markup}"
+                . "</span>";
         }
 
     }

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -201,8 +201,8 @@ class SrUtils {
         $idx_img_on_thumbnails = get_option('sr_thumbnail_idx_image', false);
 
         /** Helpers if agent or office CAN and SHOULD be shown */
-        $show_agent = !empty($agent_on_thumbnails) && !empty(trim($listing_agent));
-        $show_office = !empty($office_on_thumbnails) && !empty(trim($listing_office));
+        $show_agent = !empty($agent_on_thumbnails) && trim($listing_agent) !== "";
+        $show_office = !empty($office_on_thumbnails) && trim($listing_office) !== "";
 
         /** Initial markup */
         $listing_by = "";

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.9
+Version: 2.3.10
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This adds an admin option to the Listing Compliance Settings in the
plugin to show the listing agent name on summary thumbnails in addition
to showing the listing office. This works the same as showing the
listing office name, and can be enabled together or separately depending
on the requirements.

- [x] Update `mkListingSummaryCompliance` to accept agent name
- [x] Create compliance markup based on the two settings - agent & office
- [x] Test in list view, slider, widgets, and map thumbnails
- [x] Pass setting to sr_int_map_search

---

Example:

![image](https://user-images.githubusercontent.com/7034627/36990960-d58a37a2-206b-11e8-866d-f77f9bebd617.png)