### PR TITLE
Update "Water" label "Waterfront" on details pages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.11
+* FIX: Update "Water" label to "Waterfront" on details pages for clarity.
+
 ## 2.3.10
 * FEATURE: Add compliance option to show agent name on listing summary thumbnails.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.4
-Stable tag: 2.3.10
+Stable tag: 2.3.11
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.3.11 =
+* FIX: Update "Water" label to "Waterfront" on details pages for clarity.
 
 = 2.3.10 =
 * FEATURE: Add compliance option to show agent name on listing summary thumbnails.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -632,7 +632,7 @@ HTML;
         $accessibility = SimplyRetsApiHelper::srDetailsTable($listing_accessibility, "Accessibility");
         // waterfront
         $listing_water = $listing->property->water;
-        $water = SimplyRetsApiHelper::srDetailsTable($listing_water, "Water front");
+        $water = SimplyRetsApiHelper::srDetailsTable($listing_water, "Waterfront");
         // listing date
         $listing_list_date = $listing->listDate;
         if($listing_list_date) { $list_date_formatted = date("M j, Y", strtotime($listing_list_date)); }

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.10 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.11 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.10 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.3.11 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -632,7 +632,7 @@ HTML;
         $accessibility = SimplyRetsApiHelper::srDetailsTable($listing_accessibility, "Accessibility");
         // waterfront
         $listing_water = $listing->property->water;
-        $water = SimplyRetsApiHelper::srDetailsTable($listing_water, "Water");
+        $water = SimplyRetsApiHelper::srDetailsTable($listing_water, "Water front");
         // listing date
         $listing_list_date = $listing->listDate;
         if($listing_list_date) { $list_date_formatted = date("M j, Y", strtotime($listing_list_date)); }

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.10
+Version: 2.3.11
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Per feedback from a user: Change the label to "Water front" to be more
specific. Some users can get confused where the data says "No". If the
label is only "Water" it makes it look as if the listing doesn't have
running water, rather than no Water front view.

- [x] Update Water label on listing details pages