### PR TITLE
Fix uncaught exception in 'q' parameter search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.0
+* FIX: Fix exception when searching with "q" parameter during pagination.
+* FIX: Retain 'agent' filter on search form during pagination.
+
 ## 2.3.11
 * FIX: Update "Water" label to "Waterfront" on details pages for clarity.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.4
-Stable tag: 2.3.11
+Stable tag: 2.4.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.4.0 =
+* FIX: Fix exception when searching with "q" parameter during pagination.
+* FIX: Retain 'agent' filter on search form during pagination.
 
 = 2.3.11 =
 * FIX: Update "Water" label to "Waterfront" on details pages for clarity.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.3.11 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.3.11 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -763,6 +763,7 @@ class SimplyRetsCustomPostPages {
 
             $next_atts = $listing_params + array(
                 "q" => $kw_string,
+                "agent" => get_query_var('sr_agent', ''),
                 "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false"
             );

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -757,10 +757,9 @@ class SimplyRetsCustomPostPages {
              */
 
             // Combine sr_q and _keywords into 1 string.
-            $kw_string = implode(
-                "; ",
-                get_query_var('sr_q', array()) + array(get_query_var('sr_keywords', ''))
-            );
+            $sr_q = get_query_var('sr_q', '');
+            $sr_kw = get_query_var('sr_keywords', '');
+            $kw_string = implode("; ", array($sr_q) + array($sr_kw));
 
             $next_atts = $listing_params + array(
                 "q" => $kw_string,

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.3.11
+Version: 2.4.0
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
**Issue**
Error: Uncaught Error: Unsupported operand types

Basically, the code was - in some cases, trying to add a string and an
array, which is invalid in PHP.

The issue in the code was that `sr_q` was defaulted to an array -
instead of the resolved value being _casted_ to an array. So, if a value
was provided for `sr_q` it was never casted to an array and the
exception was thrown.

**Solution**
More specifically cast `sr_q` and `sr_keywords` to arrays only after
`get_query_var` has been called - which defaults to a string.

- [x] Fix uncaught exception
- [x] Run some test cases