### PR TITLE
Update CSS media queries for modern devices

### DIFF
--- a/assets/css/simply-rets-client.css
+++ b/assets/css/simply-rets-client.css
@@ -725,7 +725,7 @@ elsewhere, this should be a breeze.
     margin: 10px 25px 0px 0px;
 }
 
-@media screen and (max-width: 360px) {
+@media screen and (max-width: 576px) {
     .sr-adv-search-part li {
         width: 50%;
     }
@@ -760,7 +760,8 @@ elsewhere, this should be a breeze.
 /*
  * Responsive CSS
 */
-@media screen and (max-width: 360px) {
+@media screen and (max-width: 576px) {
+
     /*
      * Search results
      */
@@ -768,6 +769,7 @@ elsewhere, this should be a breeze.
         display: block;
         width: 100%;
     }
+
     .sr-primary-data {
         display: block;
         width: 100%;
@@ -775,21 +777,36 @@ elsewhere, this should be a breeze.
         padding-bottom: 5px;
         clear: both;
     }
+
     .sr-primary-data h4 {
         padding-right: 15px;
     }
+
     .sr-secondary-data {
         display: block;
         width: 100%;
     }
+
     /*
      * Search form
      */
     .sr-minmax-filters {
         display: block;
     }
-    #sr-search-ptype {
+
+    .sr-minmax-filters #sr-search-ptype,
+    .sr-minmax-filters #sr-search-keywords {
         width: 85%;
+    }
+
+    .sr-minmax-filters #sr-search-ptype select {
+        width: 100%;
+        margin-bottom: 15px;
+    }
+
+    #sr-search-wrapper .sr-sort-wrapper {
+        float: left;
+        margin-bottom: 15px;
     }
 }
 


### PR DESCRIPTION
This updates the client CSS to use `576px` as the media breakpoint
instead of `360px`. This fixes, for example, the responsive CSS not
being enabled on newer iPhones where the screen size is bigger than
`367px`. `576px` is taken from the latest bootstrap, for reference.

- [x] Update media queries
- [x] Fix minor responsive issues in the search form