### PR TITLE
Add admin option to enable/disable ListHub test events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.2
+* UPDATE: Add admin option to enable/disable ListHub analytics test events.
+
 ## 2.4.1
 * FIX: Update responsive media queries for bigger mobile device screen sizes.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.4
-Stable tag: 2.4.1
+Stable tag: 2.4.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.4.2 =
+* UPDATE: Add admin option to enable/disable ListHub analytics test events.
 
 = 2.4.1 =
 * FIX: Update responsive media queries for bigger mobile device screen sizes.

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -36,6 +36,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_additional_rooms');
       register_setting('sr_admin_settings', 'sr_listhub_analytics');
       register_setting('sr_admin_settings', 'sr_listhub_analytics_id');
+      register_setting('sr_admin_settings', 'sr_listhub_analytics_test_events');
       register_setting('sr_admin_settings', 'sr_search_map_position');
       register_setting('sr_admin_settings', 'sr_permalink_structure');
       register_setting('sr_admin_settings', 'sr_google_api_key');
@@ -481,6 +482,17 @@ class SrAdminSettings {
                         . checked(1, get_option('sr_listhub_analytics'), false) . '/>'
                       ?>
                       Enable Listhub Analytics? <i>(requires an account with Listhub)</i>
+                    </label>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_listhub_analytics_test_events" name="sr_listhub_analytics_test_events" value="1" '
+                        . checked(1, get_option('sr_listhub_analytics_test_events'), false) . '/>'
+                      ?>
+                      Send test events to ListHub <i>(disable for live events)</i>
                     </label>
                   </td>
                 </tr>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -873,15 +873,19 @@ HTML;
          * Check for ListHub Analytics
          */
         if( get_option( 'sr_listhub_analytics' ) ) {
+
             $lh_analytics = SimplyRetsApiHelper::srListhubAnalytics();
-            if( get_option( 'sr_listhub_analytics_id' ) ) {
-                $metrics_id = get_option( 'sr_listhub_analytics_id' );
+            $lh_id = get_option('sr_listhub_analytics_id', false);
+            $lh_test = get_option('sr_listhub_analytics_test_events') ? 1 : false;
+
+            if($lh_id) {
                 $lh_send_details = SimplyRetsApiHelper::srListhubSendDetails(
-                    $metrics_id
-                    , true
+                      $lh_id
+                    , $lh_test
                     , $listing_mlsid
                     , $postal_code
                 );
+
                 $lh_analytics .= $lh_send_details;
             }
         } else {
@@ -1731,7 +1735,7 @@ HTML;
 
     public static function srListhubSendDetails( $m, $t, $mlsid, $zip=NULL ) {
         $metrics_id = $m;
-        $test       = $t;
+        $test       = json_encode($t);
         $mlsid      = $mlsid;
         $zipcode    = $zip;
 

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.4.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.4.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.4.1
+Version: 2.4.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This adds an option to the admin panel for the user to control if
analytic events sent to ListHub are in test mode or not. We previously
had a flag that was always set to `true` (and I don't think ListHub
required it initially), but this now gives the user the option to set
that to `false` instead - so that events are sent in "live" mode.

- [x] Add admin option for ListHub test events
- [x] Bump version number - v2.4.2