### PR TITLE
Fix postal codes param pagination

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.3
+* FIX: Retain 'postalCodes' parameter when paginating search results.
+
 ## 2.4.2
 * UPDATE: Add admin option to enable/disable ListHub analytics test events.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.4
-Stable tag: 2.4.2
+Stable tag: 2.4.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.4.3 =
+* FIX: Retain 'postalCodes' parameter when paginating search results.
 
 = 2.4.2 =
 * UPDATE: Add admin option to enable/disable ListHub analytics test events.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.4.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.4.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -665,6 +665,14 @@ class SimplyRetsCustomPostPages {
                     $neighborhoods_string .= "&neighborhoods=$neighborhood";
                 }
             }
+
+            $postalCodes = isset($_GET['sr_postalCodes']) ? $_GET['sr_postalCodes'] : '';
+            if(!empty($postalCodes)) {
+                foreach((array)$postalCodes as $key => $postalCode) {
+                    $postalCodes_string .= "&postalCodes=$postalCode";
+                }
+            }
+
             $amenities = isset($_GET['sr_amenities']) ? $_GET['sr_amenities'] : '';
             if(!empty($amenities)) {
                 foreach((array)$amenities as $key => $amenity) {
@@ -785,6 +793,7 @@ class SimplyRetsCustomPostPages {
                 . $cities_string
                 . $counties_string
                 . $neighborhoods_string
+                . $postalCodes_string
                 . $agents_string
                 . $ptypes_string
                 . $statuses_string

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.4.2
+Version: 2.4.3
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
The postalCodes parameter wasn't being re-applied to the search results
when pagination links were hit, effectively removing them from the
queries.

This updates the plugin to make sure to reapply the postalCodes
parameter in the search results pagination if it was supplied in the
initial search or short-code.

- [x] Fix postalCodes parameter in pagination
- [x] Bump version number v2.4.3