### PR TITLE
Support null address in sr-single permalinks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.5
+* FEATURE: Support `null` address in sr-single permalinks.
+
 ## 2.4.4
 * FIX: Fix 'zip' field in ListHub analytics request.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.4
-Stable tag: 2.4.4
+Stable tag: 2.4.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.4.5 =
+* FEATURE: Support `null` address in sr-single permalinks.
 
 = 2.4.4 =
 * FIX: Fix 'zip' field in ListHub analytics request.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.4.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.4.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -78,7 +78,13 @@ class SrUtils {
         $listing_address = $listing->address->full;
 
         $listing_address_full = $listing_address
-                              . ', '
+                              // A listing might not have a null
+                              // address if a flag like "Display
+                              // address" is set to false. This just
+                              // removes the comma in these cases, but
+                              // the rest of the address remains the
+                              // same.
+                              . $listing_address ? ', ' : ''
                               . $listing_city
                               . ', '
                               . $listing_state

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.4.4
+Version: 2.4.5
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Null addresses already actually work, this just improves the formatting
of the address passed through the permalink by removing a preceding
comma if the address.full is null.

A listing may have a null address if the RETS feed has settings like
"Disp_addr" or "IDXAddressInclude" and they are set to false. This
updates the plugin to allow linking to pages even if `.address.full` is
`null`.

- [x] Format address correctly if `address.full` is missing on  `sr-single` pages.
- [x] Check/test all 3 permalink types

---

One other side note is that we could show "Undisclosed address" instead
of nothing, but showing nothing is aesthetically better.