### PR TITLE
Support 'water' parameter in sr_search_form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.4.5
+* FEATURE: Support `water` parameter on [sr_search_form].
 * FEATURE: Support `null` address in sr-single permalinks.
 
 ## 2.4.4

--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,7 @@ listing sidebar widget.
 == Changelog ==
 
 = 2.4.5 =
+* FEATURE: Support `water` parameter on [sr_search_form].
 * FEATURE: Support `null` address in sr-single permalinks.
 
 = 2.4.4 =

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -384,6 +384,7 @@ HTML;
         $vendor  = isset($atts['vendor'])  ? $atts['vendor']  : '';
         $brokers = isset($atts['brokers']) ? $atts['brokers'] : '';
         $agent   = isset($atts['agent'])   ? $atts['agent']   : '';
+        $water   = isset($atts['water'])   ? $atts['water']   : '';
         $limit   = isset($atts['limit'])   ? $atts['limit']   : '';
         $config_type = isset($atts['type']) ? $atts['type']   : '';
 
@@ -624,6 +625,7 @@ HTML;
 
                 </div>
 
+                <input type="hidden" name="water"   value="<?php echo $water; ?>"  />
                 <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
                 <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
                 <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
@@ -709,6 +711,7 @@ HTML;
                 </div>
             </div>
 
+            <input type="hidden" name="water"   value="<?php echo $water; ?>"  />
             <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
             <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
             <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -77,14 +77,14 @@ class SrUtils {
         $listing_zip = $listing->address->postalCode;
         $listing_address = $listing->address->full;
 
+        // A listing might not have a null address if a flag like
+        // "Display address" is set to false. This just removes the
+        // comma in these cases, but the rest of the address remains
+        // the same.
+        $comma = $listing_address ? ', ' : '';
+
         $listing_address_full = $listing_address
-                              // A listing might not have a null
-                              // address if a flag like "Display
-                              // address" is set to false. This just
-                              // removes the comma in these cases, but
-                              // the rest of the address remains the
-                              // same.
-                              . $listing_address ? ', ' : ''
+                              . $comma
                               . $listing_city
                               . ', '
                               . $listing_state


### PR DESCRIPTION
This adds support for setting a `water` parameter on the `[sr_search_form]` short-code.

**Example**
```
[sr_search_form water="Lake LBJ"]
```