### PR TITLE
Fix CSS and markup around more deteails link in results list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.7
+* FIX: Fix more details link CSS and markup to be more compatible.
+
 ## 2.4.6
 * ENHANCEMENT: Link to new documentation in WP readme.
 

--- a/assets/css/simply-rets-client.css
+++ b/assets/css/simply-rets-client.css
@@ -191,6 +191,17 @@ secondary data. For example, set the `.sr-data-column` to
     min-width: 15%;
 }
 
+/*
+"More details" and compliance markup shown by the listing uses this
+styling:
+*/
+.sr-listing .more-details-wrapper {
+    margin-top: 25px;
+}
+
+.sr-listing .result-compliance-markup {
+    float: right;
+}
 
 
 /*

--- a/assets/css/simply-rets-client.css
+++ b/assets/css/simply-rets-client.css
@@ -198,7 +198,8 @@ secondary data. For example, set the `.sr-data-column` to
 styling:
 */
 .sr-listing .more-details-wrapper {
-    margin-top: 25px;
+    margin-top: 5px;
+    margin-bottom: 10px;
 }
 
 .sr-listing .result-compliance-markup {

--- a/assets/css/simply-rets-client.css
+++ b/assets/css/simply-rets-client.css
@@ -62,7 +62,6 @@ of the image, use this class.
 .sr-photo {
     position: relative;
     display: inline-block;
-    float: left;
     height: 155px;
     width: 30%;
     overflow: hidden;
@@ -101,10 +100,15 @@ color is a light grey. This is very simply to change by setting:
 ```
 
 */
-.sr-primary-data {
-    width: 70%;
+.sr-listing-data-wrapper {
     display: inline-block;
+    position: relative;
+    width: 69%;
     vertical-align: top;
+}
+.sr-primary-data {
+    padding-top: 10px;
+    padding-bottom: 10px;
     background-color: #eee;
 }
 .sr-primary-data h4 {
@@ -171,10 +175,8 @@ is to change the `margin-left` property to align better in some themes.
 
 */
 .sr-secondary-data {
-    display: inline-block;
     vertical-align: top;
     padding-top: 10px;
-    width: 70%;
 }
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.4
-Stable tag: 2.4.6
+Stable tag: 2.4.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -231,6 +231,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.4.7 =
+* FIX: Fix more details link CSS and markup to be more compatible.
 
 = 2.4.6 =
 * ENHANCEMENT: Link to new documentation in WP readme.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.4.6 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.7 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.4.6 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.7 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1387,13 +1387,13 @@ HTML;
                     $areaMarkup
                   </ul>
                 </div>
-                <div style="clear:both;">
-                  <div style="text-align:right;display:block">
-                    <span style="position:absolute;left:0">
+                <div class="more-details-wrapper">
+                  <span class="more-details-link">
                       <a href="$link">More details</a>
-                    </span>
+                  </span>
+                  <span class="result-compliance-markup">
                     $compliance_markup
-                  </div>
+                  </span>
                 </div>
               </div>
 HTML;

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1369,23 +1369,25 @@ HTML;
                   <div class="sr-photo" style="background-image:url('$main_photo');">
                   </div>
                 </a>
-                <div class="sr-primary-data">
-                  <a href="$link">
-                    <h4>$address
-                    <span class="sr-price"><i>$listing_USD</i></span></h4>
-                  </a>
-                </div>
-                <div class="sr-secondary-data">
-                  <ul class="sr-data-column">
-                    $cityMarkup
-                    $yearMarkup
-                    $mlsidMarkup
-                  </ul>
-                  <ul class="sr-data-column">
-                    $bedsMarkup
-                    $bathsMarkup
-                    $areaMarkup
-                  </ul>
+                <div class="sr-listing-data-wrapper">
+                  <div class="sr-primary-data">
+                    <a href="$link">
+                      <h4>$address
+                      <span class="sr-price"><i>$listing_USD</i></span></h4>
+                    </a>
+                  </div>
+                  <div class="sr-secondary-data">
+                    <ul class="sr-data-column">
+                      $cityMarkup
+                      $yearMarkup
+                      $mlsidMarkup
+                    </ul>
+                    <ul class="sr-data-column">
+                      $bedsMarkup
+                      $bathsMarkup
+                      $areaMarkup
+                    </ul>
+                  </div>
                 </div>
                 <div class="more-details-wrapper">
                   <span class="more-details-link">

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.4.6
+Version: 2.4.7
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This should work better with more themes where the 'clear'
property doesn't work correctly with some other CSS rules.