### PR TITLE
Use typeText in additional room details

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.9
+* ENHANCEMENT: Use `typeText` field in additional room details.
+
 ## 2.4.8
 * ENHANCEMENT: Fix README teaser and update plugin directory banner image.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === SimplyRETS ===
 Author: SimplyRETS
 Contributors: SimplyRETS
-Tags: rets, idx, real estate listings, real estate, listings, rets listings, simply rets, realtor, rets feed, idx feed
+Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.7
-Stable tag: 2.4.8
+Stable tag: 2.4.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.4.9 =
+* ENHANCEMENT: Use `typeText` field in additional room details.
 
 = 2.4.8 =
 * ENHANCEMENT: Fix README teaser and update plugin directory banner image.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.4.8 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.9 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.4.8 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.4.9 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -425,6 +425,7 @@ class SimplyRetsApiHelper {
                     <tr data-attribute="$data_attr">
                       <td>$name</td>
                       <td colspan="2">$val</td>
+                    </tr>
 HTML;
             } elseif ($additional && !$desc) {
                 $val = <<<HTML
@@ -432,15 +433,18 @@ HTML;
                       <td>$name</td>
                       <td>$val</td>
                       <td>$additional</td>
+                    </tr>
 HTML;
             } else {
                 $val = <<<HTML
                     <tr data-attribute="$data_attr">
-                      <td rowspan="2" style="vertical-align: middle">$name</td>
+                      <td rowspan="2" style="vertical-align: middle;border-bottom:solid 1px #eee;">$name</td>
                       <td colspan="1">$val</td>
                       <td colspan="1">$additional</td>
+                    </tr>
                     <tr data-attribute="$data_attr">
                       <td colspan="2">$desc</td>
+                    </tr>
 HTML;
             }
         }
@@ -772,7 +776,7 @@ HTML;
                 $levelText = empty($level) ? '' : SrUtils::ordinalSuffix($level) . " level";
                 $roomsMarkup .= SimplyRetsApiHelper::srDetailsTable(
                     $roomSize,
-                    $room->type,
+                    $room->typeText,
                     $levelText,
                     $room->description
                 );

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.4.8
+Version: 2.4.9
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
If 'include additional rooms' is enabled, the name of the room is
shown using the 'typeText' field instead of the 'type' field. The
'typeText' field is usually user-defined and likely to be more
descriptive than the normalized room type.

Also minor update to table styling when displaying rooms.