### PR TITLE
Set better zoom level on maps when only 1 listing is shown

### DIFF
--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1224,13 +1224,30 @@ HTML;
             $response = array($response);
         }
 
+        $mappable_listings = array_filter($response, 'SrSearchMap::mappable');
+        $mappable_geos = SrSearchMap::uniqGeo($mappable_listings);
 
         $map       = SrSearchMap::mapWithDefaults();
         $mapHelper = SrSearchMap::srMapHelper();
-        $map->setAutoZoom(true);
         $markerCount = 0;
 
-        foreach( $response as $listing ) {
+        /**
+         * If only one listing (or one unique lat/lng) is being
+         * mapped, set a custom zoom level because the default is way
+         * to far in.
+         */
+        if (count($mappable_geos) <= 1) {
+            $map->setCenter(
+                $mappable_listings[0]->geo->lat,
+                $mappable_listings[0]->geo->lng,
+                true
+            );
+            $map->setMapOption('zoom', 12);
+        } else {
+            $map->setAutoZoom(true);
+        }
+
+        foreach( $mappable_listings as $listing ) {
             $listing_uid        = $listing->mlsId;
             $mlsid              = $listing->listingId;
             $listing_price      = $listing->listPrice;

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1224,8 +1224,8 @@ HTML;
             $response = array($response);
         }
 
-        $mappable_listings = array_filter($response, 'SrSearchMap::mappable');
-        $mappable_geos = SrSearchMap::uniqGeo($mappable_listings);
+        $mappable_listings = SrSearchMap::filter_mappable($response);
+        $uniq_geos = SrSearchMap::uniqGeos($mappable_listings);
 
         $map       = SrSearchMap::mapWithDefaults();
         $mapHelper = SrSearchMap::srMapHelper();
@@ -1236,7 +1236,7 @@ HTML;
          * mapped, set a custom zoom level because the default is way
          * to far in.
          */
-        if (count($mappable_geos) <= 1) {
+        if (count($uniq_geos) <= 1) {
             $map->setCenter(
                 $mappable_listings[0]->geo->lat,
                 $mappable_listings[0]->geo->lng,
@@ -1247,7 +1247,7 @@ HTML;
             $map->setAutoZoom(true);
         }
 
-        foreach( $mappable_listings as $listing ) {
+        foreach( $response as $listing ) {
             $listing_uid        = $listing->mlsId;
             $mlsid              = $listing->listingId;
             $listing_price      = $listing->listPrice;

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1236,10 +1236,10 @@ HTML;
          * mapped, set a custom zoom level because the default is way
          * to far in.
          */
-        if (count($uniq_geos) <= 1) {
+        if (count($uniq_geos) === 1) {
             $map->setCenter(
-                $mappable_listings[0]->geo->lat,
-                $mappable_listings[0]->geo->lng,
+                $uniq_geos[0][0],
+                $uniq_geos[0][1],
                 true
             );
             $map->setMapOption('zoom', 12);

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -179,17 +179,24 @@ HTML;
         return true;
     }
 
+    public static function filter_mappable($arr) {
+        return array_filter($arr, 'SrSearchMap::mappable');
+    }
+
     /**
      * Given a list of listings, return the number of unique lat/lng
      * pairs.
      */
-    public static function uniqGeo($arr) {
+    public static function uniqGeos($arr) {
         $tmp_geos = array();
 
         foreach($arr as $a) {
-            $temp_geos[$a->geo->lat][$a->geo->lng] = 1;
+            $tmp_geos[$a->geo->lat . $a->geo->lng] = array(
+                $a->geo->lat,
+                $a->geo->lng
+            );
         }
 
-        return $tmp_geos;
+        return array_values($tmp_geos);
     }
 }

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -165,4 +165,31 @@ HTML;
         return;
     }
 
+    /**
+     * Returns true if a listing has lat/lng - false otherwise.
+     */
+    public static function mappable($arr) {
+        $lat = $arr->geo->lat;
+        $lng = $arr->geo->lng;
+
+        if (empty($lat) OR empty($lng)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Given a list of listings, return the number of unique lat/lng
+     * pairs.
+     */
+    public static function uniqGeo($arr) {
+        $tmp_geos = array();
+
+        foreach($arr as $a) {
+            $temp_geos[$a->geo->lat][$a->geo->lng] = 1;
+        }
+
+        return $tmp_geos;
+    }
 }


### PR DESCRIPTION
Fixes #82

If only one listing is shown on a search results map, the 'auto' zoom
is enabled and it way too far zoomed in to be able to tell what's
going on.

This updates checks when rendering the map if only 1 unique
latitude/longitude pin is being placed. If so, we set a custom zoom
level of 12 around the pin, instead of using the auto zoom.