### PR TITLE
Support default 'limit' parameter on sr_map_search

### DIFF
--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -249,7 +249,6 @@ var updatePagination = function(that) {
         nextEl = null,
         pagWrapper = $_('.sr-pagination');
 
-
     if(pagWrapper.length) {
 
         pagWrapper.empty(); // clear the current pagination elements
@@ -264,11 +263,11 @@ var updatePagination = function(that) {
             pag = prev + next;
         }
 
-        if(that.offset === 0 && that.listings.length < 25) {
+        if(that.offset === 0 && that.listings.length < that.limit) {
             pag = null;
         }
 
-        if(that.offset > 0 && that.listings.length < 25) {
+        if(that.offset > 0 && that.listings.length < that.limit) {
             pag = prev;
         }
 
@@ -326,6 +325,9 @@ var getSearchFormValues = function() {
  */
 function SimplyRETSMap() {
 
+    var vendor = document.getElementById('sr-map-search').dataset.vendor
+    var limit = document.getElementById('sr-map-search').dataset.limit
+
     this.element    = 'sr-map-search';
     this.bounds     = [];
     this.markers    = [];
@@ -337,15 +339,16 @@ function SimplyRETSMap() {
     this.loaded     = false;
     this.options    = { zoom: 8 }
     this.pagination = null;
-    this.limit      = 25;
     this.offset     = 0;
     this.linkStyle  = 'default';
     this.siteRoot   = window.location.href
-    this.vendor     = document.getElementById('sr-map-search').dataset.vendor;
+    this.vendor     = vendor;
+    this.limit      = limit;
 
-    this.map     = new google.maps.Map(
+    this.map = new google.maps.Map(
         document.getElementById('sr-map-search'), this.options
     );
+
     this.loadMsg = new google.maps.InfoWindow({
         map: null,
         content: "Loading..."
@@ -636,12 +639,11 @@ SimplyRETSMap.prototype.sendRequest = function(points, params, paginate) {
 
         if(paginate === "next") {
             scrollToAnchor('sr-search-wrapper');
-            this.offset = this.offset + this.limit;
+            this.offset = Number(this.offset) + Number(this.limit);
         } else if(paginate === "prev") {
             scrollToAnchor('sr-search-wrapper');
-            this.offset = this.offset - this.limit;
+            this.offset = Number(this.offset) - Number(this.limit);
         }
-
     }
 
     var limit  = this.limit;

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -127,6 +127,13 @@ HTML;
     }
 
 
+    /**
+     * This is the handler for API requests made from the
+     * sr_map_search short-code. The client makes an AJAX request, we
+     * take the `parameters` (a query string) and pass it to the API
+     * request directly.  We return a glob of HTML that is then
+     * rendered on the client.
+     */
     public static function update_int_map_data() {
 
         // Ensure we only capture SimplyRETS requests

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -37,6 +37,12 @@ class SrShortcodes {
     }
 
 
+    /**
+     * [sr_map_search] - we return HTML with a special element that
+     * the client attaches to to render a searchable map. This is
+     * different from the other short-codes in that mostly everything
+     * after this point is handled by the client.
+     */
     public static function sr_int_map_search($atts) {
         if(!is_array($atts)) $atts = array();
 
@@ -44,7 +50,7 @@ class SrShortcodes {
         $vendor   = isset($atts['vendor'])  ? $atts['vendor']  : '';
         $brokers  = isset($atts['brokers']) ? $atts['brokers'] : '';
         $agent    = isset($atts['agent'])   ? $atts['agent']   : '';
-        $limit    = isset($atts['limit'])   ? $atts['limit']   : '';
+        $limit    = isset($atts['limit'])   ? $atts['limit'] : '25';
         $type_att = isset($atts['type'])    ? $atts['type'] : '';
 
         $content     = "";
@@ -59,6 +65,7 @@ class SrShortcodes {
                              data-idx-img='{$idx_img}'
                              data-office-on-thumbnails='{$office_on_thumbnails}'
                              data-agent-on-thumbnails='{$agent_on_thumbnails}'
+                             data-limit='{$limit}'
                              data-vendor='{$vendor}'></div>";
 
         $list_markup = !empty($atts['list_view'])


### PR DESCRIPTION
This allows the user to set an initial `limit` value on the `[sr_map_search]` short-code.

```
[sr_map_search limit="500"]
```

Historically, the `[sr_map_search]` short-code hasn't supported all of the same parameters as the `[sr_listings]` short-code (for various reasons around the way the map is implemented). However, we'd like to have more, actually complete, parody between the two, so this is a start for adding support for more filters.