### PR TITLE
Fix all PHP warning in SimplyRETS plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.5.0
+* FIX: Fix all known PHP warnings while in WP_DEBUG mode (yay!)
+* CHANGE: Add div element wrapper to search results list
+
 ## 2.4.12
 * ENHANCEMENT: Support default 'limit' on [sr_map_search]
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.7
-Stable tag: 2.4.12
+Stable tag: 2.5.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.5.0 =
+* FIX: Fix all known PHP warnings while in WP_DEBUG mode (yay!)
+* CHANGE: Add div element wrapper to search results list
 
 = 2.4.12 =
 * ENHANCEMENT: Support default 'limit' on [sr_map_search]

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -14,7 +14,7 @@ add_action("admin_notices", array("SrAdminSettings", "adminMessages"));
 
 class SrAdminSettings {
 
-  function add_to_admin_menu() {
+  public static function add_to_admin_menu() {
       add_options_page('SimplyRETS Settings'
                        , 'SimplyRETS'
                        , 'manage_options'
@@ -23,7 +23,7 @@ class SrAdminSettings {
       );
   }
 
-  function register_admin_settings() {
+  public static function register_admin_settings() {
       register_setting('sr_admin_settings', 'sr_api_name');
       register_setting('sr_admin_settings', 'sr_api_key');
       register_setting('sr_admin_settings', 'sr_contact_page');
@@ -82,7 +82,7 @@ class SrAdminSettings {
       }
   }
 
-  function sr_admin_page() {
+  public static function sr_admin_page() {
       global $wpdb;
       $logo_path = plugin_dir_url(__FILE__) . 'assets/img/logo_button.png';
 

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.4.12 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.4.12 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -306,7 +306,7 @@ class SimplyRetsApiHelper {
 
         // get link val from header
         $pag_links = array();
-        $match_count = preg_match('/^Link: ([^\r\n]*)[\r\n]*$/m', $linkHeader, $matches);
+        preg_match('/^Link: ([^\r\n]*)[\r\n]*$/m', $linkHeader, $matches);
         unset($matches[0]);
 
         foreach( $matches as $key => $val ) {
@@ -315,7 +315,6 @@ class SimplyRetsApiHelper {
                 if( strpos( $part, 'rel="prev"' ) == true ) {
                     $part = trim( $part );
                     preg_match( '/^<(.*)>/', $part, $prevLink );
-                    // $prevLink = $part;
                 }
                 if( strpos( $part, 'rel="next"' ) == true ) {
                     $part = trim( $part );
@@ -323,13 +322,11 @@ class SimplyRetsApiHelper {
                 }
             }
         }
-
-        $prev_link = $match_count > 0 AND $prevLink[1] ? $prevLink[1] : "";
-        $next_link = $match_count > 0 AND $nextLink[1] ? $nextLink[1] : "";
+        $prev_link = (!empty($prevLink) AND $prevLink[1]) ? $prevLink[1] : "";
+        $next_link = (!empty($nextLink) AND $nextLink[1]) ? $nextLink[1] : "";
 
         $pag_links['prev'] = $prev_link;
         $pag_links['next'] = $next_link;
-
 
         /**
          * Transform query parameters to what the Wordpress client needs
@@ -1256,6 +1253,7 @@ HTML;
             $map->setAutoZoom(true);
         }
 
+        $resultsMarkup = "";
         foreach( $response as $listing ) {
             $listing_uid        = $listing->mlsId;
             $mlsid              = $listing->listingId;
@@ -1432,6 +1430,7 @@ HTML;
 
         }
 
+        $resultsMarkup = "<div id=\"sr-listings-results-list\">{$resultsMarkup}</div>";
         $markerCount > 0 ? $mapMarkup = $mapHelper->render($map) : $mapMarkup = '';
 
         if( $map_setting == 'false' ) {

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -95,8 +95,8 @@ class SimplyRetsCustomPostPages {
 		$rules = array(
             'listings/([^&]+)/([^&]+)/([^&]+)/([^&]+)/([^&]+)/?$'
             => 'index.php?sr-listings=sr-single&sr_city=$matches[1]&sr_state=$matches[2]&sr_zip=$matches[3]&listing_title=$matches[4]&listing_id=$matches[5]',
-			"listings/(.*)/(.*)?$"
-                => "index.php?sr-listings=sr-single&listing_id=$matches[1]&listing_title=$matches[2]"
+			'listings/(.*)/(.*)?$'
+                => 'index.php?sr-listings=sr-single&listing_id=$matches[1]&listing_title=$matches[2]'
 		);
         return $incoming + $rules;
     }
@@ -633,6 +633,7 @@ class SimplyRetsCustomPostPages {
              */
 
             $features = isset($_GET['sr_features']) ? $_GET['sr_features'] : '';
+            $features_string = "";
             if(!empty($features)) {
                 foreach((array)$features as $key => $feature) {
                     $features_string .= "&features=$feature";
@@ -640,6 +641,7 @@ class SimplyRetsCustomPostPages {
             }
 
             $cities = isset($_GET['sr_cities']) ? $_GET['sr_cities'] : '';
+            $cities_string = "";
             if(!empty($cities)) {
                 foreach((array)$cities as $key => $city) {
                     $cities_string .= "&cities=$city";
@@ -647,6 +649,7 @@ class SimplyRetsCustomPostPages {
             }
 
             $counties = isset($_GET['sr_counties']) ? $_GET['sr_counties'] : '';
+            $counties_string = "";
             if(!empty($counties)) {
                 foreach((array)$counties as $key => $county) {
                     $counties_string .= "&counties=$county";
@@ -654,6 +657,7 @@ class SimplyRetsCustomPostPages {
             }
 
             $agents = isset($_GET['sr_agent']) ? $_GET['sr_agent'] : '';
+            $agents_string = "";
             if(!empty($agents)) {
                 foreach((array)$agents as $key => $agent) {
                     $agents_string .= "&agent=$agent";
@@ -661,6 +665,7 @@ class SimplyRetsCustomPostPages {
             }
 
             $neighborhoods = isset($_GET['sr_neighborhoods']) ? $_GET['sr_neighborhoods'] : '';
+            $neighborhoods_string = "";
             if(!empty($neighborhoods)) {
                 foreach((array)$neighborhoods as $key => $neighborhood) {
                     $neighborhoods_string .= "&neighborhoods=$neighborhood";
@@ -668,6 +673,7 @@ class SimplyRetsCustomPostPages {
             }
 
             $postalCodes = isset($_GET['sr_postalCodes']) ? $_GET['sr_postalCodes'] : '';
+            $postalCodes_string = "";
             if(!empty($postalCodes)) {
                 foreach((array)$postalCodes as $key => $postalCode) {
                     $postalCodes_string .= "&postalCodes=$postalCode";
@@ -675,6 +681,7 @@ class SimplyRetsCustomPostPages {
             }
 
             $amenities = isset($_GET['sr_amenities']) ? $_GET['sr_amenities'] : '';
+            $amenities_string = "";
             if(!empty($amenities)) {
                 foreach((array)$amenities as $key => $amenity) {
                     $amenities_string .= "&amenities=$amenity";
@@ -839,11 +846,12 @@ class SimplyRetsCustomPostPages {
 
         // if we catch a singlelisting query, create a new post on the fly
         global $wp_query;
+        $wpq = $wp_query->query;
 
-        if( $wp_query->query['sr-listings'] == 'sr-search'
-            AND array_key_exists("listing_id", $wp_query->query_vars)
-            AND array_key_exists("listing_title", $wp_query->query_vars)
-            OR $wp_query->query['sr-listings'] == "sr-single"
+        if( (!empty($wpq['sr-listings']) AND $wpq['sr-listings'] == 'sr-search') AND
+            array_key_exists("listing_id", $wp_query->query_vars) AND
+            array_key_exists("listing_title", $wp_query->query_vars) OR
+            (!empty($wpq['sr-listings']) AND $wpq['sr-listings'] == "sr-single")
         ) {
 
             $post_id    = urldecode(get_query_var( 'listing_id', '' ));
@@ -872,7 +880,7 @@ class SimplyRetsCustomPostPages {
             return $posts + array($post);
         }
         // if we catch a search results query, create a new post on the fly
-        if( $wp_query->query['sr-listings'] == "sr-search" ) {
+        if(!empty($wpq['sr-listings']) AND $wpq['sr-listings'] == "sr-search") {
 
             $post_id = get_query_var( 'sr_minprice', '9998' );
 

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -180,7 +180,7 @@ HTML;
      * to show a single listing.
      * ie, [sr_residential mlsid="12345"]
      */
-    public function sr_residential_shortcode( $atts ) {
+    public static function sr_residential_shortcode( $atts ) {
         global $wp_query;
 
         /**

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -430,12 +430,10 @@ HTML;
             $adv_cities = $atts['cities'];
         }
 
-        if( !$sort  == "" ) {
-            $sort_price_hl = ($sort == "-listprice") ? "selected" : '';
-            $sort_price_lh = ($sort == "listprice")  ? "selected" : '';
-            $sort_date_hl  = ($sort == "-listdate")  ? "selected" : '';
-            $sort_date_lh  = ($sort == "listdate")   ? "selected" : '';
-        }
+        $sort_price_hl = ($sort == "-listprice") ? "selected" : '';
+        $sort_price_lh = ($sort == "listprice")  ? "selected" : '';
+        $sort_date_hl  = ($sort == "-listdate")  ? "selected" : '';
+        $sort_date_lh  = ($sort == "listdate")   ? "selected" : '';
 
         /**
          * Advanced Search Form.
@@ -447,6 +445,7 @@ HTML;
          * *amenities (int/ext), *status (active, pending, sold), area.
          */
         $type_options             = '';
+        $status_options           = "";
         $available_property_types = get_option("sr_adv_search_meta_types_$vendor", array());
         $default_type_option      = '<option value="">Property Type</option>';
 
@@ -475,6 +474,7 @@ HTML;
             }
         }
 
+        $city_options = "";
         $adv_search_cities = get_option("sr_adv_search_meta_city_$vendor", array());
         sort($adv_search_cities);
         foreach( (array)$adv_search_cities as $key=>$city ) {
@@ -491,6 +491,7 @@ HTML;
             }
         }
 
+        $location_options = "";
         $adv_search_neighborhoods= get_option("sr_adv_search_meta_neighborhoods_$vendor", array());
         sort( $adv_search_neighborhoods );
         foreach( (array)$adv_search_neighborhoods as $key=>$neighborhood) {
@@ -499,6 +500,7 @@ HTML;
         }
 
 
+        $features_options = "";
         $adv_search_features = get_option("sr_adv_search_meta_features_$vendor", array());
         sort( $adv_search_features );
         foreach( (array)$adv_search_features as $key=>$feature) {

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -161,9 +161,14 @@ class SrUtils {
      * @result $arr - the query string in array form
      */
     public static function proper_parse_str($str) {
+
+        if (empty($str)) {
+            return array();
+        }
+
         $arr = array();
-        # split on outer delimiter
         $pairs = explode('&', $str);
+
         foreach ($pairs as $i) {
 
             list($name,$value) = explode('=', $i, 2);
@@ -289,7 +294,6 @@ class SrUtils {
 
         // Initialize variables
         $listing_by;
-        $listing_by_markup;
 
         // Ensure we have all the info we need
         $agentOfficeAboveTheFoldEnabled = get_option(
@@ -307,7 +311,7 @@ class SrUtils {
                 $listing_by .= "Listing by: ";
                 $listing_by .= "<strong>$agent</strong>, ";
                 $listing_by .= "<strong>$office</strong>";
-                $listing_by_markup = "<p>$listing_by</p>";
+                return "<p>$listing_by</p>";
 
             } elseif (empty($agent) AND !empty($office)) {
 
@@ -315,7 +319,7 @@ class SrUtils {
                  * Only office name is available, show that
                  */
                 $listing_by = "Listing by: <strong>$office</strong>";
-                $listing_by_markup = "<p>$listing_by</p>";
+                return "<p>$listing_by</p>";
 
             } elseif (!empty($agent) AND empty($office)) {
 
@@ -323,19 +327,14 @@ class SrUtils {
                  * Only agent name is available, show that
                  */
                 $listing_by = "Listing by: <strong>$agent</strong>";
-                $listing_by_markup = "<p>$listing_by</p>";
+                return "<p>$listing_by</p>";
 
             } else {
-
-                /**
-                 * No agen or office available, don't show anything
-                 */
-                $listing_by = "";
-                $listing_by_markup = "";
+                return "";
             }
         }
 
-        return $listing_by_markup;
+        return "";
     }
 
     /**

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.4.12
+Version: 2.5.0
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
There's a bunch of warnings thrown by the SimplyRETS plugin when
`WP_DEBUG` is enabled on the site, and they're completely ugly.

This fixes them.

We need to look at where the changes hit, and test those spots
specifically to make sure everything is working as it was.

- [x] Fix pagination function (just returning a boolean instead of the
  string).
- [x] Test changes, tag, and release