### PR TITLE
Fix error rendering mutltiple Google maps on the same page

### DIFF
--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -782,7 +782,7 @@ $_(document).ready(function() {
 
     if(document.getElementById('sr-map-search')) {
 
-        if(typeof google === 'object' && typeof googlemaps === 'object') {
+        if(typeof google === 'object' && typeof google.maps === 'object') {
             // google.maps exists - start map
             startMap();
 

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -32,8 +32,23 @@ class SrSearchMap {
 
     public static function mapWithDefaults() {
         $map = new Map();
-        $map->setAsync(true);
-        $map->setHtmlContainerId('sr_map_canvas');
+
+        // Generate an ident for the map so you can render mutliple
+        // maps on the same page. This isn't the most stable solution,
+        // but we don't have unique identifiers about the current
+        // short-code (and even if we did, it's very possible someone
+        // might want to show two of the same short-codes on the same
+        // page.
+        $ident = rand();
+        $map->setHtmlContainerId("{$ident}");
+
+        // Don't use async so that you can render multiple maps on the
+        // same page. When `async` is true, each map (each short-code)
+        // fetches it's own Google Maps script, causing conflict
+        // errors if there are multiple on the same page. Async does
+        // not have this problem.
+        $map->setAsync(false);
+
         $map->setStylesheetOptions(array(
             'width' => '100%',
             'height' =>  '550px'


### PR DESCRIPTION
Two changes to how we load map fix this issue:
- Don't load maps with `async`. When doing this, the Google Maps API is automatically included for each short-code. Disabling this only includes it once (there's no perf diff).
- Give a unique ID to each map. This implementation is a little unstable, being a random integer, but I think it will hold. We don't have any other unique information when the function is called.

----

**One Gotcha**: `[sr_listings]` will work multiple times on the same page, and `[sr_map_search]` will work multiple times on the same page. However, you can not (currently) use `[sr_map_search]` on a page where `[sr_listings]` is showing a map.

Reason being: when `[sr_listings]` loads the map, it does not include the `drawingManager` that is used by `[sr_map_search]`. sr_map_search does load it's own library, but if google maps has already been loaded on the page, it does not. Thus, an error is thrown that it can't find the drawing Manager.

This should be a "somewhat" easy fix, but am curious if it is an imminent use-case.