### PR TITLE
Load all available google maps libraries

### DIFF
--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -49,6 +49,13 @@ class SrSearchMap {
         // not have this problem.
         $map->setAsync(false);
 
+        $map->setLibraries(array(
+            "autocomplete",
+            "drawing",
+            "places",
+            "vizualization"
+        ));
+
         $map->setStylesheetOptions(array(
             'width' => '100%',
             'height' =>  '550px'


### PR DESCRIPTION
Fixes #99 

The basic issue is that Google Maps can only be loaded once a page. Some plugins use additional libraries with google maps (eg, `[sr_map_search]` uses the `drawing` library).

If two plugins on the same page both require maps, they should check if Google Maps is already loaded. **SimplyRETS handles this.**

However, if SimplyRETS loads _first_ and a subsequent plugin requires, for example, the `places` library, then that second plugin will fail because the library is not available.

This change includes all available libraries when we load Google maps. Overall, this will improve resilience with other plugins and cause fewer errors. **The size difference is only `0.1kb`**.

It also allows us to use `[sr_listings]` and `[sr_map_search]` on the same page.

Google has _no_ way of loading maps _after the fact_, so this is kind of a common issue on WordPress: https://issuetracker.google.com/issues/35820648