### PR TITLE
Add admin option to customize no results message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.2
+* ENHANCEMENT: Add admin option to customize no search results message.
+
 ## 2.5.1
 * FIX: Fix error when loading multiple maps with [sr_listings]
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.7
-Stable tag: 2.5.1
+Stable tag: 2.5.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.5.2 =
+* ENHANCEMENT: Add admin option to customize no search results message.
 
 = 2.5.1 =
 * FIX: Fix error when loading multiple maps with [sr_listings]

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -44,6 +44,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_agent_on_thumbnails');
       register_setting('sr_admin_settings', 'sr_thumbnail_idx_image');
       register_setting('sr_admin_settings', 'sr_custom_disclaimer');
+      register_setting('sr_admin_settings', 'sr_custom_no_results_message');
       register_setting('sr_admin_settings', 'sr_show_mls_status_text');
       register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
       register_setting('sr_admin_settings', 'sr_show_mls_trademark_symbol');
@@ -99,6 +100,15 @@ class SrAdminSettings {
       // so we can properly sanitize the input.
       if (isset( $_POST['sr_custom_disclaimer'] )) {
           update_option('sr_custom_disclaimer', htmlentities(stripslashes($_POST['sr_custom_disclaimer'])));
+      }
+
+      // Custom POST handler for updating the custom disclaimer
+      // so we can properly sanitize the input.
+      if (isset( $_POST['sr_custom_no_results_message'] )) {
+          update_option(
+              'sr_custom_no_results_message',
+              htmlentities(stripslashes($_POST['sr_custom_no_results_message']))
+          );
       }
 
       ?>
@@ -517,8 +527,8 @@ class SrAdminSettings {
               <textarea
                   id="sr_custom_disclaimer"
                   name="sr_custom_disclaimer"
-                  cols="75"
-                  rows="10"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
+                  cols="50"
+                  rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
               <ul>
                   <li>
                       - Use the variable "{lastUpdate}" to interpolate
@@ -528,6 +538,25 @@ class SrAdminSettings {
                       - You can use HTML or plain text.
                   </li>
               </ul>
+              <?php submit_button(); ?>
+          </form>
+        </div>
+        <div>
+          <h3>No search results message</h3>
+          <p>The messasge shown when a search doesn't return results.</p>
+          <form method="post" action="options-general.php?page=simplyrets-admin.php">
+              <textarea
+                  id="sr_custom_no_results_message"
+                  name="sr_custom_no_results_message"
+                  cols="50"
+                  rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
+              <div>
+                  <i>
+                      Default: There are 0 listings that match this
+                      search. Try broadening your search criteria or
+                      try again later.
+                  </i>
+              </div>
               <?php submit_button(); ?>
           </form>
         </div>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.5.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.5.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -382,6 +382,12 @@ class SrMessages {
             );
         }
 
+        /** Use custom message from admin settings, if set. */
+        $customMsg = get_option('sr_custom_no_results_message');
+        if ($customMsg !== false && $customMsg !== "") {
+            return $customMsg;
+        }
+
         $noResultsMsg = "<br><p><strong>There are 0 listings that match this search. "
                          . "Please try to broaden your search criteria or feel free to try again later.</p></strong>";
         return $noResultsMsg;

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.5.1
+Version: 2.5.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Adds a new option to the admin panel to customize the message shown when a search doesn't match any results. The existing message worked for _most_ cases, but we've had a lot of users over time request this, so it should help people make their site their own!