### PR TITLE
[feedback] Show sale price for Closed listings on details page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.4
+* ENHANCEMENT: Show sale price for Closed listings on details pages.
+
 ## 2.5.3
 * FIX: Fix logic for loading custom single-sr-listings.php template.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 4.9.7
-Stable tag: 2.5.3
+Stable tag: 2.5.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.5.4 =
+* ENHANCEMENT: Show sale price for Closed listings on details pages.
 
 = 2.5.3 =
 * FIX: Fix logic for loading custom single-sr-listings.php template.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.5.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.5.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -535,6 +535,13 @@ HTML;
         $listing_price = $listing->listPrice;
         $listing_price_USD = '$' . number_format( $listing_price );
         $price = SimplyRetsApiHelper::srDetailsTable($listing_price_USD, "Price");
+
+        $listing_close_price = null;
+        if ($listing->mls->status === "Closed" AND !empty($listing->sales)) {
+            $listing_close_price = '$' . number_format($listing->sales->closePrice);
+        }
+        $close_price = SimplyRetsApiHelper::srDetailsTable($listing_close_price, "Close price");
+
         // DOM
         $listing_days_on_market = $listing->mls->daysOnMarket;
         $days_on_market = SimplyRetsApiHelper::srDetailsTable($listing_days_on_market, "Days on market");
@@ -1076,6 +1083,7 @@ HTML;
                   <th colspan="3"><h5>Property Details</h5></th></tr></thead>
               <tbody>
                 $price
+                $close_price
                 $bedrooms
                 $bathsFull
                 $bathsHalf

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.5.3
+Version: 2.5.4
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
@creichert 	- wanted to run this by you. This adds a table entry to the listing details pages that shows the sale price.  Two questions:

1. Do you think we should be showing this price everywhere (namely, search results)
2. Should we add an admin option to show/hide the sales price on that page (maybe for display requirements in certain areas).