### PR TITLE
Fix invalid markup - add setting to disable map on listing pages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.5.5
+* ENHANCEMENT: Add admin option to disable maps on listing details pages.
+* ENHANCEMENT: Increase compatibility tag for WordPress 5.0
+* FIX: Fix issue with generating invalid markup
+
 ## 2.5.4
 * FIX: Fix `vendor` parameter on [sr_map_search] short-code.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 4.9.7
-Stable tag: 2.5.4
+Tested up to: 5.0.0
+Stable tag: 2.5.5
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,11 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.5.5 =
+* ENHANCEMENT: Add admin option to disable maps on listing details pages.
+* ENHANCEMENT: Increase compatibility tag for WordPress 5.0
+* FIX: Fix issue with generating invalid markup
 
 = 2.5.4 =
 * FIX: Fix `vendor` parameter on [sr_map_search] short-code.

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -48,6 +48,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_show_mls_status_text');
       register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
       register_setting('sr_admin_settings', 'sr_show_mls_trademark_symbol');
+      register_setting('sr_admin_settings', 'sr_disable_listing_details_map');
   }
 
   public static function adminMessages () {
@@ -200,6 +201,22 @@ class SrAdminSettings {
                   <td>
                     <p><strong>Send Lead Capture forms submissions to:<p></strong>
                     <input type="email" name="sr_leadcapture_recipient" value="<?php echo esc_attr( get_option('sr_leadcapture_recipient') ); ?>" />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <h3>Map settings</h3>
+            <table>
+              <tbody>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_disable_listing_details_map" name="sr_disable_listing_details_map" value="1" '
+                        . checked(1, get_option('sr_disable_listing_details_map'), false) . '/>'
+                      ?>
+                        Disable map view on listing details page
+                    </label>
                   </td>
                 </tr>
               </tbody>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.5.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.5.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.5 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -976,10 +976,12 @@ HTML;
 
         $addrFull = $address . ', ' . $city . ' ' . $listing_postal_code;
 
-        if( $listing_lat  && $listing_longitude ) {
-            /**
-             * Google Map for single listing
-             **************************************************/
+        /**
+         * Google Map for single listing
+         */
+        $hide_map = get_option('sr_disable_listing_details_map', false);
+
+        if( $listing_lat  && $listing_longitude && !$hide_map ) {
             $map       = SrSearchMap::mapWithDefaults();
             $marker    = SrSearchMap::markerWithDefaults();
             $iw        = SrSearchMap::infoWindowWithDefaults();

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -87,9 +87,9 @@ class SrShortcodes {
             $type_options = "";
             foreach($prop_types as $key=>$type) {
                 if( $type == $type_att) {
-                    $type_options .= "<option value='$type' selected />$type</option>";
+                    $type_options .= "<option value='$type' selected>$type</option>";
                 } else {
-                    $type_options .= "<option value='$type' />$type</option>";
+                    $type_options .= "<option value='$type'>$type</option>";
                 }
             }
 

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.5.4
+Version: 2.5.5
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Per a report by a client, this fixes invalid HTML tags in the search
form markup. Additionally, this adds an option to prevent loading
Google Maps on the listing details pages (like you can do on other
pages).

Also, increase the "Tested up to" tag to support WordPress 5.0