### PR TITLE
Pass raw address string to infoWindowMarkup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.6
+* FIX: Remove extra markup from listing details map info window.
+
 ## 2.5.5
 * ENHANCEMENT: Add admin option to disable maps on listing details pages.
 * ENHANCEMENT: Increase compatibility tag for WordPress 5.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.0.0
-Stable tag: 2.5.5
+Stable tag: 2.5.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.5.6 =
+* FIX: Remove extra markup from listing details map info window.
 
 = 2.5.5 =
 * ENHANCEMENT: Add admin option to disable maps on listing details pages.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -989,7 +989,7 @@ HTML;
             $iwCont    = SrSearchMap::infoWindowMarkup(
                 $link,
                 $main_photo,
-                $address,
+                $listing_address,
                 $listing_price_USD,
                 $listing_bedrooms,
                 $listing_bathsFull,

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.5.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.5.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.5.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.5.5
+Version: 2.5.6
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
The issue is right now, we're passing the address after it's been made
into HTML with the `srDetailsTable` function. This updates the listing
details page to use the raw "address.full" data in the map marker info
window.

You can see the issue in this picture, that the address has extra
markup (the "Address" at the beginning):

![image](https://user-images.githubusercontent.com/7034627/50173588-8e3dcc80-02bd-11e9-89f5-e78e7b60239b.png)
