### PR TITLE
Support cities, counties, and neighborhoods parameters on [sr_search_form]

### DIFF
--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -819,7 +819,7 @@ class SimplyRetsCustomPostPages {
                 "postalCodes" => $postalCodes,
                 "cities" => $cities,
                 "counties" => $counties,
-                "neighborhoods" => $neighborhood
+                "neighborhoods" => $neighborhoods
             );
 
             // Create a string of attributes to put on the

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -511,6 +511,27 @@ class SimplyRetsCustomPostPages {
         return $new_template;
     }
 
+    /**
+     * When loading a sr-listings page, this function will parse a GET
+     * (search) parameter, and return the original values, formatting
+     * query string, and an array of the values.
+     */
+    public static function parseGetParameter($name, $key, $params) {
+        $param = isset($_GET[$name]) ? $_GET[$name] : "";
+        $param_arr = is_array($param) ? $param : explode(";", $param);
+        $param_str = "";
+
+        if(is_array($param_arr) && !empty($param_arr)) {
+            foreach((array)$param_arr as $idx => $val) {
+                if (!empty($val)) {
+                    $final = trim($val);
+                    $param_str .= "&{$key}={$final}";
+                }
+            }
+        }
+
+        return array("param" => $param, "query" => $param_str);
+    }
 
     public static function srPostDefaultContent( $content ) {
         require_once( plugin_dir_path(__FILE__) . 'simply-rets-api-helper.php' );
@@ -645,50 +666,11 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
-            $cities = isset($_GET['sr_cities']) ? $_GET['sr_cities'] : '';
-            $cities_string = "";
-            if(!empty($cities)) {
-                foreach((array)$cities as $key => $city) {
-                    $cities_string .= "&cities=$city";
-                }
-            }
-
-            $counties = isset($_GET['sr_counties']) ? $_GET['sr_counties'] : '';
-            $counties_string = "";
-            if(!empty($counties)) {
-                foreach((array)$counties as $key => $county) {
-                    $counties_string .= "&counties=$county";
-                }
-            }
-
             $agents = isset($_GET['sr_agent']) ? $_GET['sr_agent'] : '';
             $agents_string = "";
             if(!empty($agents)) {
                 foreach((array)$agents as $key => $agent) {
                     $agents_string .= "&agent=$agent";
-                }
-            }
-
-            $neighborhoods = isset($_GET['sr_neighborhoods']) ? $_GET['sr_neighborhoods'] : '';
-            $neighborhoods_string = "";
-            if(!empty($neighborhoods)) {
-                foreach((array)$neighborhoods as $key => $neighborhood) {
-                    $neighborhoods_string .= "&neighborhoods=$neighborhood";
-                }
-            }
-
-            /** Parse multiple postalCodes from short-code parameter */
-            $postalCodes = isset($_GET['sr_postalCodes']) ? $_GET['sr_postalCodes'] : '';
-            $postalCodes_string = "";
-            $postalCodes_arr = is_array($postalCodes) ? $postalCodes : explode(";", $postalCodes);
-
-            if(is_array($postalCodes_arr) && !empty($postalCodes_arr)) {
-                foreach((array)$postalCodes_arr as $key => $zip) {
-                    // Don't send empty postalCodes parameters to the API
-                    if (!empty($zip)) {
-                        $final = trim($zip);
-                        $postalCodes_string .= "&postalCodes=$zip";
-                    }
                 }
             }
 
@@ -699,6 +681,46 @@ class SimplyRetsCustomPostPages {
                     $amenities_string .= "&amenities=$amenity";
                 }
             }
+
+            /** Parse multiple postalCodes from short-code parameter */
+            $postalCodesData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_postalCodes",
+                "postalCodes",
+                $_GET
+            );
+
+            $postalCodes = $postalCodesData["param"];
+            $postalCodes_string = $postalCodesData["query"];
+
+            /** Parse multiple cities from short-code parameter */
+            $citiesData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_cities",
+                "cities",
+                $_GET
+            );
+
+            $cities = $citiesData["param"];
+            $cities_string = $citiesData["query"];
+
+            /** Parse multiple counties from short-code parameter */
+            $countiesData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_counties",
+                "counties",
+                $_GET
+            );
+
+            $counties = $countiesData["param"];
+            $counties_string = $countiesData["query"];
+
+            /** Parse multiple neighborhoods from short-code parameter */
+            $neighborhoodsData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_neighborhoods",
+                "neighborhoods",
+                $_GET
+            );
+
+            $neighborhoods = $neighborhoodsData["param"];
+            $neighborhoods_string = $neighborhoodsData["query"];
 
             /**
              * If `sr_q` is set, the user clicked a pagination link
@@ -794,7 +816,10 @@ class SimplyRetsCustomPostPages {
                 "agent" => get_query_var('sr_agent', ''),
                 "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false",
-                "postalCodes" => $postalCodes
+                "postalCodes" => $postalCodes,
+                "cities" => $cities,
+                "counties" => $counties,
+                "neighborhoods" => $neighborhood
             );
 
             // Create a string of attributes to put on the

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -430,7 +430,7 @@ HTML;
          */
         $adv_cities = isset($_GET['sr_cities']) ? $_GET['sr_cities'] : array();
         if (empty($adv_cities) && array_key_exists('cities', $atts)) {
-            $adv_cities = $atts['cities'];
+            $adv_cities = explode(";", $atts['cities']);
         }
 
         $sort_price_hl = ($sort == "-listprice") ? "selected" : '';

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -396,6 +396,8 @@ HTML;
         $config_type = isset($atts['type']) ? $atts['type']   : '';
         $counties = isset($atts['counties']) ? $atts['counties'] : '';
         $postalCodes = isset($atts['postalcodes']) ? $atts['postalcodes'] : '';
+        $neighborhoods = isset($atts['neighborhoods']) ? $atts['neighborhoods'] : '';
+        $cities = isset($atts['cities']) ? $atts['cities'] : '';
 
         if($config_type === '') {
             $config_type = isset($_GET['sr_ptype']) ? $_GET['sr_ptype'] : '';
@@ -730,6 +732,8 @@ HTML;
             <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
             <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
             <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
+            <input type="hidden" name="sr_neighborhoods" value="<?php echo $neighborhoods; ?>" />
+            <input type="hidden" name="sr_cities" value="<?php echo $cities; ?>" />
             <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
             <input type="hidden" name="status"     value="<?php echo $adv_status; ?>" />
 


### PR DESCRIPTION
A follow-up to #113 that makes more parameters available with the same
functionality.

You can now specify parameters on the `[sr_search_form]` short-code
for `cities`, `counties`, and `neighborhoods`. For example:

```
[sr_search_form counties="..." cities="..." neighborhoods=".."]
```

This will persist these values in the search form so that a user can
create "area specific" search forms, restricting what the user can
actually search.