### PR TITLE
Fix and improve attributes on advanced search form markup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.1
+* FIX: Fix class and ID attributes on advanced search form markup.
+
 ## 2.6.0
 * ENHANCEMENT: Allow `neighborhoods`, `cities`, and `counties` parameters on [sr_search_form].
 * ENHANCEMENT: Support ActiveUnderContract listings in SimplyRETS widgets.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 5.0.3
-Stable tag: 2.6.0
+Tested up to: 5.1.1
+Stable tag: 2.6.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.6.1 =
+* FIX: Fix class and ID attributes on advanced search form markup.
 
 = 2.6.0 =
 * ENHANCEMENT: Allow `neighborhoods`, `cities`, and `counties` parameters on [sr_search_form].

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.6.0 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.6.1 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.6.0 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.6.1 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -562,9 +562,11 @@ HTML;
                       <input step="1000" min="0" type="number" name="sr_maxprice" placeholder="1000000" value="<?php echo $maxprice; ?>"/>
                     </div>
 
-                    <div class="sr-adv-search-col4">
-                      <label for="sr-adv-minprice"><strong>Bedrooms</strong></label>
-                      <select name="sr_minbeds" id="sr-adv-minbeds">
+                    <div class="sr-adv-search-col4" id="sr-adv-minbeds">
+                      <label for="sr_minbeds" id="sr-adv-minbeds-label">
+                          <strong>Bedrooms</strong>
+                      </label>
+                      <select name="sr_minbeds" id="sr-adv-minbeds-select">
                         <option value="<?php echo $minbeds; ?>"><?php echo $minbeds; ?>+</option>
                         <option value="1">1+</option>
                         <option value="2">2+</option>
@@ -576,9 +578,12 @@ HTML;
                         <option value="8">8+</option>
                       </select>
                     </div>
-                    <div class="sr-adv-search-col4">
-                      <label><strong>Bathrooms</strong></label>
-                      <select name="sr_minbaths" id="sr-adv-minbaths">
+
+                    <div class="sr-adv-search-col4" id="sr-adv-minbaths">
+                      <label for="sr_minbaths" id="sr-adv-minbaths-label">
+                          <strong>Bathrooms</strong>
+                      </label>
+                      <select name="sr_minbaths" id="sr-adv-minbaths-select">
                         <option value="<?php echo $minbaths; ?>"><?php echo $minbaths; ?>+</option>
                         <option value="1">1+</option>
                         <option value="2">2+</option>
@@ -593,33 +598,35 @@ HTML;
                   </div>
 
                   <div class="sr-minmax-filters">
-                    <div class="sr-adv-search-col2">
-                      <label><strong>Status</strong></label>
-                      <select name="status" id="sr-adv-search-status">
+                    <div class="sr-adv-search-col2" id="sr-adv-status">
+                      <label for="status" id="sr-adv-status-label">
+                          <strong>Status</strong>
+                      </label>
+                      <select name="status" id="sr-adv-status-select">
                         <option value="">All</option>
                         <?php echo $status_options; ?>
                       </select>
                     </div>
-                    <div class="sr-adv-search-col4">
-                      <label for="sr-adv-lotsize"><strong>Lot Size</strong></label>
+                    <div class="sr-adv-search-col4" id="sr-adv-lotsize">
+                      <label for="sr_lotsize"><strong>Lot Size</strong></label>
                       <input type="number" name="sr_lotsize" placeholder="3500" value="<?php echo $lotsize; ?>"/>
                     </div>
-                    <div class="sr-adv-search-col4">
-                      <label><strong>Area (SqFt)</strong></label>
+                    <div class="sr-adv-search-col4" id="sr-adv-area">
+                      <label for="sr_area"><strong>Area (SqFt)</strong></label>
                       <input type="number" name="sr_area" value="<?php echo $area; ?>" placeholder="1500" />
                     </div>
                   </div>
 
 
                   <div class="sr-minmax-filters">
-                    <div class="sr-adv-search-col2">
+                    <div class="sr-adv-search-col2" id="sr-adv-cities">
                       <label><strong>Cities</strong></label>
                       <select name='sr_cities[]' multiple>
                         <?php echo $city_options ?>
                       </select>
                     </div>
 
-                    <div class="sr-adv-search-col2">
+                    <div class="sr-adv-search-col2" id="sr-adv-neighborhoods">
                       <label><strong>Locations</strong></label>
                       <select name="sr_neighborhoods[]" multiple>
                         <?php echo $location_options ?>

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.6.0
+Version: 2.6.1
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Currently there is no way to target specific parts of the advanced search form HTML with CSS, to hide or modify the display of certain things. Mostly just adding `id` attributes, but also fixing a couple of typos:

- [x] Add `id` attribute to "Bedrooms" field _(`#sr-adv-minbeds`)_
- [x] Add `id` attribute to "Bathrooms" field _(`#sr-adv-minbaths`)_
- [x] Add `id` attribute to "Status" field  _(`#sr-adv-status`)_
- [x] Add `id` attribute to "Lot size" field  _(`#sr-adv-lotsize`)_
- [x] Add `id` attribute to "Area (sq ft)" field  _(`#sr-adv-area`)_
- [x] Add `id` attribute to "Cities" field  _(`#sr-adv-cities`)_
- [x] Add `id` attribute to "Locations" field  _(`#sr-adv-neighborhoods`)_