### PR TITLE
Support `subtype` parameter - display property type and subType

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.2
+* ENHANCEMENT: Display property type and subtype on listing details page
+* ENHANCEMENT: Add support for subtype parameter on [sr_listings] and [sr_search_form]
+
 ## 2.6.1
 * FIX: Fix class and ID attributes on advanced search form markup.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.1.1
-Stable tag: 2.6.1
+Stable tag: 2.6.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.6.2 =
+* ENHANCEMENT: Display property type and subtype on listing details page
+* ENHANCEMENT: Add support for subtype parameter on [sr_listings] and [sr_search_form]
 
 = 2.6.1 =
 * FIX: Fix class and ID attributes on advanced search form markup.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.6.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.6.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.6.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.6.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -539,8 +539,15 @@ HTML;
         $listing_days_on_market = $listing->mls->daysOnMarket;
         $days_on_market = SimplyRetsApiHelper::srDetailsTable($listing_days_on_market, "Days on market");
         // type
-        $listing_type = $listing->property->type;
+        $listing_type = SrUtils::normalizePropertyType($listing->property->type);
         $type = SimplyRetsApiHelper::srDetailsTable($listing_type, "Property Type");
+        // subtype
+        $listing_subType_ = $listing->property->subType;
+        $listing_subTypeText = $listing->property->subTypeText;
+        $listing_subType = !empty($listing_subType_)
+                         ? $listing_subType_
+                         : $listing_subTypeText;
+        $subType = SimplyRetsApiHelper::srDetailsTable($listing_subType, "Sub Type");
         // bedrooms
         $listing_bedrooms = $listing->property->bedrooms;
         $bedrooms = SimplyRetsApiHelper::srDetailsTable($listing_bedrooms, "Bedrooms");
@@ -1089,6 +1096,8 @@ HTML;
                 $lotsizeareaunits_markup
                 $acres_markup
 
+                $type
+                $subType
                 $stories
                 $interiorFeatures
                 $exteriorFeatures

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -181,6 +181,7 @@ class SimplyRetsCustomPostPages {
         $vars[] = "sr_keywords";
         $vars[] = "sr_type";
         $vars[] = "sr_ptype";
+        $vars[] = "sr_subtype";
         $vars[] = "sr_agent";
         $vars[] = "sr_brokers";
         $vars[] = "sr_sort";
@@ -519,6 +520,7 @@ class SimplyRetsCustomPostPages {
     public static function parseGetParameter($name, $key, $params) {
         $param = isset($_GET[$name]) ? $_GET[$name] : "";
         $param_arr = is_array($param) ? $param : explode(";", $param);
+        $param_att = is_array($param) ? implode(";", $param) : $param;
         $param_str = "";
 
         if(is_array($param_arr) && !empty($param_arr)) {
@@ -530,7 +532,11 @@ class SimplyRetsCustomPostPages {
             }
         }
 
-        return array("param" => $param, "query" => $param_str);
+        return array(
+            "param" => $param,
+            "query" => $param_str,
+            "att" => $param_att
+        );
     }
 
     public static function srPostDefaultContent( $content ) {
@@ -692,6 +698,17 @@ class SimplyRetsCustomPostPages {
             $postalCodes = $postalCodesData["param"];
             $postalCodes_string = $postalCodesData["query"];
 
+            /** Parse multiple subtypes from short-code parameter */
+            $subtypeData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_subtype",
+                "subtype",
+                $_GET
+            );
+
+            $subtype = $subtypeData["param"];
+            $subtype_att = $subtypeData["att"];
+            $subtype_string = $subtypeData["query"];
+
             /** Parse multiple cities from short-code parameter */
             $citiesData = SimplyRetsCustomPostPages::parseGetParameter(
                 "sr_cities",
@@ -816,6 +833,7 @@ class SimplyRetsCustomPostPages {
                 "agent" => get_query_var('sr_agent', ''),
                 "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false",
+                "subtype" => $subtype_att,
                 "postalCodes" => $postalCodes,
                 "cities" => $cities,
                 "counties" => $counties,
@@ -842,6 +860,7 @@ class SimplyRetsCustomPostPages {
                 . $postalCodes_string
                 . $agents_string
                 . $ptypes_string
+                . $subtype_string
                 . $statuses_string
                 . $amenities_string
                 . $q_string;

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -268,6 +268,15 @@ HTML;
                 $ptypes_string = str_replace(' ', '%20', $ptypes_string );
             }
 
+            if(isset($listing_params['subtype']) && !empty($listing_params['subtype'])) {
+                $subtypes = explode(';', $listing_params['subtype']);
+                foreach($subtypes as $key => $subtype) {
+                    $subtype = trim($subtype);
+                    $subtypes_string .= "subtype=$subtype&";
+                }
+                $subtypes_string = str_replace(' ', '%20', $subtypes_string);
+            }
+
             if( isset( $listing_params['postalcodes'] ) && !empty( $listing_params['postalcodes'] ) ) {
                 $postalcodes = explode( ';', $listing_params['postalcodes'] );
                 foreach( $postalcodes as $key => $postalcode  ) {
@@ -321,6 +330,7 @@ HTML;
                     && $key !== 'cities'
                     && $key !== 'agent'
                     && $key !== 'type'
+                    && $key !== 'subtype'
                     && $key !== 'status'
                     && $key !== 'q'
                 ) {
@@ -339,6 +349,7 @@ HTML;
             $qs .= $params_string;
             $qs .= $agents_string;
             $qs .= $ptypes_string;
+            $qs .= $subtypes_string;
             $qs .= $statuses_string;
             $qs .= $q_string;
 
@@ -394,6 +405,7 @@ HTML;
         $water   = isset($atts['water'])   ? $atts['water']   : '';
         $limit   = isset($atts['limit'])   ? $atts['limit']   : '';
         $config_type = isset($atts['type']) ? $atts['type']   : '';
+        $subtype = isset($atts['subtype']) ? $atts['subtype'] : '';
         $counties = isset($atts['counties']) ? $atts['counties'] : '';
         $postalCodes = isset($atts['postalcodes']) ? $atts['postalcodes'] : '';
         $neighborhoods = isset($atts['neighborhoods']) ? $atts['neighborhoods'] : '';
@@ -649,6 +661,7 @@ HTML;
                 <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
                 <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
                 <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
+                <input type="hidden" name="sr_subtype" value="<?php echo $subtype; ?>" />
                 <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
                 <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
                 <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
@@ -737,6 +750,7 @@ HTML;
             <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
             <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
             <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
+            <input type="hidden" name="sr_subtype" value="<?php echo $subtype; ?>" />
             <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
             <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
             <input type="hidden" name="sr_neighborhoods" value="<?php echo $neighborhoods; ?>" />

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -48,6 +48,46 @@ class SrUtils {
     }
 
     /**
+     * Normalize a property type abbreviation into the full text.
+     */
+    public static function normalizePropertyType($type) {
+        $normalized_type = null;
+
+        switch($type) {
+            case "RES":
+                $normalized_type = "Residential";
+                break;
+
+            case "CND":
+                $normalized_type = "Condominium";
+                break;
+
+            case "RNT":
+                $normalized_type = "Rental";
+                break;
+
+            case "CRE":
+                $normalized_type = "Commercial";
+                break;
+
+            case "LND":
+                $normalized_type = "Land";
+                break;
+
+            case "MLF":
+                $normalized_type = "MultiFamily";
+                break;
+
+            case "FRM":
+                $normalized_type = "Farm";
+                break;
+
+        }
+
+        return $normalized_type;
+    }
+
+    /**
      * Builds a link to a listings' details page. Used in search results.
      */
     public static function buildDetailsLink($listing, $params = array()) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.6.1
+Version: 2.6.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Two updates here:

1. Add support for the `type` and `subtype` parameter on `[sr_listings]` and `[sr_search_form]`
2. Display the property type and subtype on listing details pages (fixes #54). Uses subTypeText as a backup if subType is null.