### PR TITLE
Fix duplicate 'County' text on search results page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.6.4
+* FIX: Fix issue where the text "County" is duplicated on search result pages.
+
 ## 2.6.3
 * ENHANCEMENT: Show listing close price on property details page
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.1.1
-Stable tag: 2.6.3
+Stable tag: 2.6.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.6.4 =
+* FIX: Fix issue where the text "County" is duplicated on search result pages.
 
 = 2.6.3 =
 * ENHANCEMENT: Show listing close price on property details page

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1384,7 +1384,11 @@ HTML;
             if( $area == 0 ) {
                 $areaMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($bathsHalf, 'Half Baths', false);
                 if( $areaMarkup == 0 ) {
-                    $areaMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($county, "County", false);
+                    $areaMarkup = SimplyRetsApiHelper::resultDataColumnMarkup(
+                        SrUtils::normalizeCountyText($county),
+                        "County",
+                        false
+                    );
                 }
             }
 

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.6.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.6.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.6.3 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.6.4 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -88,6 +88,17 @@ class SrUtils {
     }
 
     /**
+     * Remove trailing "County" (or "county") from a county name so it
+     * can be shown within our details builder, or in other use-cases
+     * where "County" may be appended manually.
+     */
+    public static function normalizeCountyText($county) {
+        $county_text = str_replace(" County", "", $county);
+        $county_text = str_replace(" county", "", $county_text);
+        return $county_text;
+    }
+
+    /**
      * Builds a link to a listings' details page. Used in search results.
      */
     public static function buildDetailsLink($listing, $params = array()) {

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.6.3
+Version: 2.6.4
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Fixes a bug where we append "County" to text that already contains "County", causing duplicate text on the search results page.

This just adds a simple util function that will remove " County" (or " county") from a string so that we can append ours without duplication in the text.

See: SEFMLS. They always put "County" at the end of their values.

---

Here's the fix. Previously it said "Miami-Dade County County".
![image](https://user-images.githubusercontent.com/7034627/57255876-cb132180-701a-11e9-8d96-6071ca7ea738.png)
