### PR TITLE
Use full address with city/state/zip in listing search results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
+dist: trusty
 language: php
 
 php:
-    - 5.4
     - 5.6
+    - 7.1
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
     - WP_VERSION=latest WP_MULTISITE=1
-    - WP_VERSION=3.8 WP_MULTISITE=0
-    - WP_VERSION=3.8 WP_MULTISITE=1
+    - WP_VERSION=4.0 WP_MULTISITE=0
+    - WP_VERSION=4.0 WP_MULTISITE=1
 
 before_script:
     - composer self-update
     - composer install --prefer-source --no-interaction --dev
-    - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 
+    - chmod +x tests/init.sh && bash tests/init.sh $TRAVIS_PHP_VERSION $WP_VERSION
 
 script: phpunit

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.7.0
+* ENHANCEMENT: Show full address with city, state, and zip for listings in search results.
+
 ## 2.6.4
 * FIX: Fix issue where the text "County" is duplicated on search result pages.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.1.1
-Stable tag: 2.6.4
+Stable tag: 2.7.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.7.0 =
+* ENHANCEMENT: Show full address with city, state, and zip for listings in search results.
 
 = 2.6.4 =
 * FIX: Fix issue where the text "County" is duplicated on search result pages.

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.6.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.7.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.6.4 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.7.0 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -988,8 +988,6 @@ HTML;
             !empty($vendor) ? array("sr_vendor" => $vendor) : array()
         );
 
-        $addrFull = $address . ', ' . $city . ' ' . $listing_postal_code;
-
         /**
          * Google Map for single listing
          */
@@ -1301,8 +1299,8 @@ HTML;
              * Listing status to show. This may return a statusText.
              */
             $mls_status = SrListing::listingStatus($listing);
+            $full_address = SrUtils::buildFullAddressString($listing);
 
-            $addrFull = $address . ', ' . $city . ' ' . $zip;
             $listing_USD = $listing_price == "" ? "" : '$' . number_format( $listing_price );
 
             if( $bedrooms == null || $bedrooms == "" ) {
@@ -1349,7 +1347,7 @@ HTML;
                 $iwCont = SrSearchMap::infoWindowMarkup(
                     $link,
                     $main_photo,
-                    $address,
+                    $full_address,
                     $listing_USD,
                     $bedrooms,
                     $bathsFull,
@@ -1423,8 +1421,9 @@ HTML;
                 <div class="sr-listing-data-wrapper">
                   <div class="sr-primary-data">
                     <a href="$link">
-                      <h4>$address
-                      <span class="sr-price"><i>$listing_USD</i></span></h4>
+                      <h4>$full_address
+                        <small class="sr-price"><i> - $listing_USD</i></small>
+                      </h4>
                     </a>
                   </div>
                   <div class="sr-secondary-data">

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -104,7 +104,7 @@ class SrSearchMap {
 
         $markup = <<<HTML
             <div class="sr-iw-inner">
-              <h4 class="sr-iw-addr">$address<small> $price</small></h4>
+              <h4 class="sr-iw-addr">$address<small> - $price</small></h4>
               <div class="sr-iw-inner__img">
                 <a href='$link'>
                   <img id="sr-iw-inner__img-img" src='$photo'>

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -99,6 +99,25 @@ class SrUtils {
     }
 
     /**
+     * Render a listings full address with state and postalCode
+     * <street address>, <city>, <state> <zip>
+     */
+    public static function buildFullAddressString($listing) {
+
+        $city = $listing->address->city;
+        $state = $listing->address->state;
+        $zip = $listing->address->postalCode;
+        $address = $listing->address->full;
+
+        // A listing might have a null address if a flag like "Display
+        // address" is set to false. This just removes the comma in
+        // these cases, but the rest of the address remains the same.
+        $comma = $address ? ', ' : '';
+
+        return $address . $comma . $city . ', ' . $state . ' ' . $zip;
+    }
+
+    /**
      * Builds a link to a listings' details page. Used in search results.
      */
     public static function buildDetailsLink($listing, $params = array()) {
@@ -122,25 +141,11 @@ class SrUtils {
 
         // Listing details
         $listing_id = $listing->mlsId;
-
         $listing_city = $listing->address->city;
         $listing_state = $listing->address->state;
         $listing_zip = $listing->address->postalCode;
         $listing_address = $listing->address->full;
-
-        // A listing might not have a null address if a flag like
-        // "Display address" is set to false. This just removes the
-        // comma in these cases, but the rest of the address remains
-        // the same.
-        $comma = $listing_address ? ', ' : '';
-
-        $listing_address_full = $listing_address
-                              . $comma
-                              . $listing_city
-                              . ', '
-                              . $listing_state
-                              . ' '
-                              . $listing_zip;
+        $listing_address_full = SrUtils::buildFullAddressString($listing);
 
         if($prettify && $custom_permalink_struct === "pretty_extra") {
 

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.6.4
+Version: 2.7.0
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015

--- a/tests/init.sh
+++ b/tests/init.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+TRAVIS_PHP_VERSION=${1-0}
+WP_VERSION=${2-latest}
+
+echo "[init-tests.sh] TRAVIS_PHP_VERSION=$TRAVIS_PHP_VERSION"
+echo "[init-tests.sh] WP_VERSION=$WP_VERSION"
+
+# PHP 7 is incompatible with WordPress v4 and lower so we force WordPress 5.0
+if [[ $TRAVIS_PHP_VERSION == "7.1"* && $WP_VERSION == 4.0 ]]; then
+    echo "[notice] PHP 7 is incompatible with WordPress v4 and lower. Forcing WordPress 5.0."
+    WP_VERSION=5.0
+else
+    :
+fi
+
+echo "[init-tests.sh] Using WP_VERSION $WP_VERSION"
+
+bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
This updates the search results view to show the full address with
city, state, and zip code for each search result item.

Previously we were only showing the street address, without the city
and additional information. Adding this information should have some
good SEO benefits because: 1) there's more information to index, and
2) the link text to the listing details page matches the title of the
listing details page itself.

**NOTE** There are a few other spots (widgets, slider, etc) where we
still only show the street address and not the full address. I want to
make sure this change doesn't break too many people's styles/theme/etc
before changing it in too many spots.

![image](https://user-images.githubusercontent.com/7034627/61009857-c4b26600-a339-11e9-962f-5690f217c183.png)
