### PR TITLE
Add support for openhouses search results and details pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ stop:
 .phony: logs
 logs:
 	docker-compose logs -f wordpress
+
+.phony: zip
+zip: deps
+	zip -r simplyretswp-dev.zip src/

--- a/simply-rets-openhouses.php
+++ b/simply-rets-openhouses.php
@@ -16,12 +16,15 @@ class SimplyRetsOpenHouses {
      * Generate markup /openhouses search response.
      */
     public static function openHousesSearchResults($search_response) {
-        $markup = "";
         $res = $search_response["response"];
+        $pag = $search_response["pagination"];
+
+        $markup = "";
+        $pagination = SrUtils::buildPaginationLinks($pag);
 
         if(array_key_exists("error", $res)) {
 
-            $markup = <<<HTML
+            $markup .= <<<HTML
               <div class="sr-error-message">
                 <p>
                   <strong>Error: {$res->error}</strong>
@@ -29,12 +32,22 @@ class SimplyRetsOpenHouses {
               </div>
 HTML;
 
+        } else if (count($res) === 0) {
+
+            return SrMessages::noResultsMsg($res);
+
         } else {
 
             foreach($res as $idx=>$oh) {
                 $markup .= SimplyRetsOpenHouses::openHouseSearchResultMarkup($oh);
             }
 
+            $markup .= <<<HTML
+              <div class="sr-pagination-wrapper">
+                <hr/>
+                {$pagination["prev"]} {$pagination["next"]}
+              </div>
+HTML;
         }
 
         return $markup;
@@ -88,9 +101,7 @@ HTML;
         $open_house_banner = "<div style=\"{$banner_style}\">"
                            . "  <strong>Open house</strong>"
                            . "  <br/>"
-                           . "  {$day_date}"
-                           . "  <br/>"
-                           . "  {$start_end_time}"
+                           . "  {$day_date} &middot; {$start_end_time}"
                            . "</div>";
 
         $status = $listing->mls->status;

--- a/simply-rets-openhouses.php
+++ b/simply-rets-openhouses.php
@@ -17,13 +17,26 @@ class SimplyRetsOpenHouses {
      */
     public static function openHousesSearchResults($search_response) {
         $markup = "";
+        $res = $search_response["response"];
 
-        if(!array_key_exists("response", $search_response)) {
-            return $markup;
-        }
+        if(array_key_exists("error", $res)) {
 
-        foreach($search_response["response"] as $idx=>$oh) {
-            $markup .= SimplyRetsOpenHouses::openHouseSearchResultMarkup($oh);
+            $markup = <<<HTML
+              <div class="sr-error-message">
+                <p>
+                  <strong>Error: {$res->error}</strong>
+                  <br/>
+                  <span>{$res->help}</span>
+                </p>
+              </div>
+HTML;
+
+        } else {
+
+            foreach($res as $idx=>$oh) {
+                $markup .= SimplyRetsOpenHouses::openHouseSearchResultMarkup($oh);
+            }
+
         }
 
         return $markup;

--- a/simply-rets-openhouses.php
+++ b/simply-rets-openhouses.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * simply-rets-api-helper.php - Copyright (C) 2014-2015 SimplyRETS, Inc.
+ *
+ * This file provides a class that has functions for retrieving and parsing
+ * data from the remote retsd api.
+ *
+*/
+
+/* Code starts here */
+
+class SimplyRetsOpenHouses {
+
+    /**
+     * Generate markup /openhouses search response.
+     */
+    public static function openHousesSearchResults($search_response) {
+        $markup = "";
+
+        if(!array_key_exists("response", $search_response)) {
+            return $markup;
+        }
+
+        foreach($search_response["response"] as $idx=>$oh) {
+            $markup .= SimplyRetsOpenHouses::openHouseSearchResultMarkup($oh);
+        }
+
+        return $markup;
+    }
+
+    /**
+     * Generate markup for a single open house search result
+     */
+    public static function openHouseSearchResultMarkup($openhouse) {
+        $listing = $openhouse->listing;
+        $full_address = SrUtils::buildFullAddressString($listing);
+        $details_link = SrUtils::buildDetailsLink($listing);
+        $list_price_fmtd = '$' . number_format($listing->listPrice);
+        $listing_id = $listing->listingId;
+
+        $dummy = plugins_url( 'assets/img/defprop.jpg', __FILE__ );
+        $main_photo = !empty($listing->photos) ? $listing->photos[0] : $dummy;
+        $photo_style = "background-image:url('$main_photo');background-size:cover;";
+
+        $listing_office = $listing->office->name;
+        $listing_agent = $listing->agent->firstName . ' ' . $listing->agent->lastName;
+        $compliance_markup = SrUtils::mkListingSummaryCompliance(
+            $listing_office,
+            $listing_agent
+        );
+
+        date_default_timezone_set("America/Los_Angeles");
+        $date = date("F j, Y", strtotime($openhouse->startTime));
+        $day = date("F j", strtotime($openhouse->startTime));
+        $start = date("g:ia", strtotime($openhouse->startTime));
+        $end = date("g:ia", strtotime($openhouse->endTime));
+        $tz = date("e", strtotime($openhouse->startTime));
+        $time = "<span>{$start} - {$end}</span>";
+
+        $status = $listing->mls->status;
+        $bedrooms = !empty($listing->property->bedrooms)
+                  ? "<strong>Bedrooms: </strong> {$listing->property->bedrooms}<br/>"
+                  : "";
+
+        $bathrooms = !empty($listing->property->bathrooms)
+                   ? "<strong>Bathrooms: </strong> {$listing->property->bathrooms}<br/>"
+                   : !empty($listing->bathsFull)
+                   ? "<strong>Baths full: </strong> {$listing->property->bathsFull}<br/>"
+                   : "";
+
+        $mls_area = $listing->mls->area;
+        $county = $listing->geo->county;
+        $area = !empty($mls_area)
+              ? strlen($mls_area) >= 50 ? "{$mls_area}..." : "{$mls_area}"
+              : !empty($county)
+              ? strlen($county) >= 50 ? "{$county}..." : "{$county}"
+              : "";
+        $area = "<strong>Area: </strong> {$area}<br/>";
+
+        $living_area = !empty($listing->property->area)
+                     ? number_format($listing->property->area)
+                     : "";
+
+        $sqft = !empty($living_area) ? "<strong>SqFt: </strong>{$living_area}sqft<br/>" : "";
+
+        $banner_style = "position:absolute;z-index:1;padding:10px;font-size:1.1rem;width:30%;"
+                      . "background-color:green;border-radius:2px;color:white;bottom:3%";
+
+        $open_house_banner = "<div style=\"{$banner_style}\">"
+                      . "Open house {$day}, {$time}"
+                      . "</div>";
+
+        return <<<HTML
+          <hr>
+          <div class="sr-listing">
+            <a href="$details_link" style="text-decoration:none">
+              $open_house_banner
+              <div class="sr-photo" style="$photo_style">
+              </div>
+            </a>
+            <div class="sr-listing-data-wrapper">
+              <div class="sr-primary-data">
+                <a href="$details_link">
+                  <h4>$full_address
+                    <small class="sr-price"><i> - $list_price_fmtd</i></small>
+                  </h4>
+                </a>
+              </div>
+              <div class="sr-secondary-data">
+                <p class="sr-data-column">
+                  <strong>Listing status: </strong> $status<br/>
+                  <strong>MLS #: </strong> $listing_id<br/>
+                  $area
+                </p>
+                <p class="sr-data-column">
+                  $bedrooms
+                  $bathrooms
+                  $sqft
+                </p>
+              </div>
+            </div>
+            <div class="more-details-wrapper">
+              <span style="visibility:hidden">clearfix</span>
+              <span class="more-details-link" style="float:right">
+                  <a href="$details_link">More details</a>
+              </span>
+              <span class="result-compliance-markup">
+                $compliance_markup
+              </span>
+            </div>
+          </div>
+HTML;
+    }
+}

--- a/src/assets/css/simply-rets-client.css
+++ b/src/assets/css/simply-rets-client.css
@@ -226,6 +226,10 @@ for the whole page with this class.
 */
 
 .sr-details {
+    margin-top: 10px;
+}
+
+.sr-details table {
     margin-top: 15px;
 }
 
@@ -314,6 +318,26 @@ the class or the id, depending on what you need.
 
 .sr-remarks-details p {
     line-height: 20px !important;
+    margin-bottom: 0px;
+    padding-bottom: 5px;
+}
+
+.sr-listing-openhouses-banner {
+    border-left: solid 1px #eee;
+    border-right: solid 1px #eee;
+    border-top: solid 1px #eee;
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-top: 15px;
+}
+
+.sr-listing-openhouses-banner h3 {
+    margin-bottom: 5px;
+}
+
+.sr-listing-openhouses-banner-item {
+    display: inline-block;
+    width: 25%;
 }
 
 /*

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -55,7 +55,25 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_idx_address_display_text', array(
           "default" => "Undisclosed address"
       ));
+      register_setting('sr_admin_settings', 'sr_date_default_timezone', array(
+          "default" => ""
+      ));
   }
+
+  public static $timezones = array(
+      "Eastern (US)" => "America/New_York",
+      "Central (US)" => "America/Chicago",
+      "Mountain (US)" => "America/Denver",
+      "Pacific (US)" => "America/Los_Angeles",
+      "Alaska (US)" => "America/Anchorage",
+      "Hawaii (US)" => "Pacific/Honolulu",
+      "Newfoundland (Canada)" => "America/St_Johns",
+      "Atlantic (Canada)" => "America/Halifax",
+      "Eastern (Canada)" => "America/Toronto",
+      "Central (Canada)" => "America/Winnipeg",
+      "Mountain (Canada)" => "America/Edmonton",
+      "Pacific (Canada)" => "America/Vancouver"
+  );
 
   public static function adminMessages () {
       $page_created = get_option("sr_demo_page_created", false);
@@ -320,6 +338,41 @@ class SrAdminSettings {
           </div>
           <?php submit_button(); ?>
           <hr>
+
+          <div class="sr-admin-open-house-settings">
+            <h2>Open house settings</h2>
+            <h3 style="margin-bottom:5px;">
+                Default timezone
+            </h3>
+            <table>
+              <tbody>
+                <tr>
+                  <td colspan="2">
+                      <select name="sr_date_default_timezone">
+                          <option value="">None</option>
+                          <?php foreach(SrAdminSettings::$timezones as $txt=>$tz) { ?>
+                              <option
+                                  value="<?php echo $tz; ?>"
+                                  <?php selected(
+                                      get_option("sr_date_default_timezone"), $tz);
+                                  ?>>
+                                  <?php echo $txt; ?>
+                              </option>
+                          <?php } ?>
+                      </select>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p style="margin-top:0px;">
+                Select the timezone used to display open house start
+                and end times.<br/>If you don't want to convert any
+                timestamps, select "None".
+            </p>
+          </div>
+          <?php submit_button(); ?>
+          <hr>
+
           <div class="sr-admin-settings">
             <h2>Listing Compliance Settings</h2>
             <h3>Show listing agent and office information</h3>

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -20,9 +20,16 @@ class SimplyRetsApiHelper {
         return $response_markup;
     }
 
+    public static function retrieveOpenHousesResults($params, $settings = NULL) {
+        $request_url = SimplyRetsApiHelper::srRequestUrlBuilder($params, "openhouses");
+        $response = SimplyRetsApiHelper::srApiRequest($request_url);
+        $response_markup  = SimplyRetsOpenHouses::openHousesSearchResults($response);
+
+        return $response_markup;
+    }
 
     public static function retrieveListingDetails( $listing_id ) {
-        $request_url      = SimplyRetsApiHelper::srRequestUrlBuilder($listing_id, true);
+        $request_url      = SimplyRetsApiHelper::srRequestUrlBuilder($listing_id, "properties", true);
         $request_response = SimplyRetsApiHelper::srApiRequest( $request_url );
         $response_markup  = SimplyRetsApiHelper::srResidentialDetailsGenerator( $request_response );
 
@@ -68,10 +75,15 @@ class SimplyRetsApiHelper {
      *
      * base url for local development: http://localhost:3001/properties
     */
-    public static function srRequestUrlBuilder($params, $single_listing = false) {
+    public static function srRequestUrlBuilder(
+        $params,
+        $endpoint = "properties",
+        $single_listing = false
+    ) {
+
         $authid   = get_option( 'sr_api_name' );
         $authkey  = get_option( 'sr_api_key' );
-        $base_url = "https://{$authid}:{$authkey}@api.simplyrets.com/properties";
+        $base_url = "https://{$authid}:{$authkey}@api.simplyrets.com/{$endpoint}";
 
         // Return early for /properties/{mlsId} requests
         if ($single_listing === true) {

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1042,15 +1042,14 @@ HTML;
 
         $upcoming_openhouses = count($openhouses);
         $next_openhouses = $upcoming_openhouses > 0
-                         ? array_slice($openhouses, 0, 3)
+                         ? array_slice($openhouses, 0, 4)
                          : NULL;
 
         $next_openhouses_banner = "";
         if ($next_openhouses) {
 
             $next_openhouses_details = "";
-            $next_openhouses_item_style = "display:inline-block; width:33%";
-            $next_openhouses_item_class = "display:inline-block; width:33%";
+            $next_openhouses_item_class = "sr-listing-openhouses-banner-item";
 
             foreach($next_openhouses as $next_oh) {
 
@@ -1062,20 +1061,19 @@ HTML;
                 $next_oh_time = $next_oh_times["time"];
 
                 $next_openhouses_details .=
-                      "<div class=\"{$next_openhouses_item_class}\""
-                    . "     style=\"{$next_openhouses_item_style}\">"
+                      "<div class=\"{$next_openhouses_item_class}\">"
                     . "  <strong>{$next_oh_day}</strong>"
                     . "  <br/>"
                     . "  <span>{$next_oh_time}</span>"
                     . "</div>";
             }
 
+            $upcoming_openhouses_text =
+                $upcoming_openhouses === 1 ? "upcoming open house" : "upcoming open houses";
+
             $next_openhouses_banner = <<<HTML
-                <div style="margin-top:15px;margin-bottom:15px"
-                     class="sr-listing-openhouses-banner">
-                  <h2 style="margin-top:5px">
-                    $upcoming_openhouses upcoming open houses
-                  </h2>
+                <div class="sr-listing-openhouses-banner">
+                  <h3>$upcoming_openhouses $upcoming_openhouses_text</h3>
                   $next_openhouses_details
                 </div>
 HTML;

--- a/src/simply-rets-openhouses.php
+++ b/src/simply-rets-openhouses.php
@@ -18,7 +18,7 @@ class SimplyRetsOpenHouses {
      */
     public static function getOpenHousesByListingId($listing_id) {
         $response = SimplyRetsApiHelper::makeApiRequest(
-            array("listingId" => $listing_id, "startdate" => "2019-11-11"),
+            array("listingId" => $listing_id, "startdate" => date("Y-m-d")),
             "openhouses"
         );
 

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -569,20 +569,19 @@ class SimplyRetsCustomPostPages {
             global $wp_query;
 
             $parameters = $wp_query->query;
-            $allowed = array_flip(["/sr_/", "limit", "offset"]);
             $searchParameters = array_intersect_key(
                 $parameters,
                 array_flip(
                     array_merge(
                         preg_grep('/sr_.*/', array_keys($parameters)),
-                        preg_grep('/(limit|offset)/', array_keys($parameters)),
+                        preg_grep('/(limit|offset)/', array_keys($parameters))
                     )
                 )
             );
 
             $shortcodeAttributes = array_combine(
                 preg_replace("/sr_/", "", array_keys($searchParameters)),
-                array_values($searchParameters),
+                array_values($searchParameters)
             );
 
             $nextAttributes = "";

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -565,6 +565,35 @@ class SimplyRetsCustomPostPages {
             return $content;
         }
 
+        if ($page_name === "sr-openhouses") {
+            global $wp_query;
+
+            $parameters = $wp_query->query;
+            $allowed = array_flip(["/sr_/", "limit", "offset"]);
+            $searchParameters = array_intersect_key(
+                $parameters,
+                array_flip(
+                    array_merge(
+                        preg_grep('/sr_.*/', array_keys($parameters)),
+                        preg_grep('/(limit|offset)/', array_keys($parameters)),
+                    )
+                )
+            );
+
+            $shortcodeAttributes = array_combine(
+                preg_replace("/sr_/", "", array_keys($searchParameters)),
+                array_values($searchParameters),
+            );
+
+            $nextAttributes = "";
+            foreach($shortcodeAttributes as $name=>$value) {
+                $nextValue = is_array($value) ? implode("; ", $value) : $value;
+                $nextAttributes .= $name . '="' . $nextValue . '" ';
+            }
+
+            return do_shortcode( "[sr_openhouses $nextAttributes]");
+        }
+
         if ( $page_name == 'sr-search' ) {
             $minbeds  = get_query_var( 'sr_minbeds',  '' );
             $maxbeds  = get_query_var( 'sr_maxbeds',  '' );
@@ -955,6 +984,26 @@ class SimplyRetsCustomPostPages {
                 "post_parent"    => 0,
                 "post_status"    => "publish",
                 "post_title"     => "Search Results",
+                "post_type"      => "sr-listings"
+            );
+
+            return $posts + array($post);
+        }
+
+        if(!empty($wpq['sr-listings']) AND $wpq['sr-listings'] == "sr-openhouses") {
+
+            $post = (object)array(
+                "ID"             => "sr-openhouses-dynamic-post",
+                "comment_count"  => 0,
+                "comment_status" => "closed",
+                "ping_status"    => "closed",
+                "post_author"    => 1,
+                "post_name"      => "Open houses search results",
+                "post_date"      => date("c"),
+                "post_date_gmt"  => gmdate("c"),
+                "post_parent"    => 0,
+                "post_status"    => "publish",
+                "post_title"     => "Open houses search results",
                 "post_type"      => "sr-listings"
             );
 

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -192,6 +192,13 @@ HTML;
     }
 
 
+    public static function sr_openhouses_shortcode($atts) {
+        $search_parameters = !is_array($atts) ? array() : $atts;
+        $listings_content = SimplyRetsApiHelper::retrieveOpenHousesResults($search_parameters);
+        return $listings_content;
+    }
+
+
     /**
      * [sr_residential] - Residential Listings Shortcode
      *
@@ -384,22 +391,6 @@ HTML;
         $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $listing_params, $atts );
         return $listings_content;
     }
-
-
-    /**
-     * Open Houses Shortcode - [sr_openhouses]
-     *
-     * this is pulling condos and obviously needs to be pulling open houses
-     */
-    public static function sr_openhouses_shortcode() {
-        $listing_params = array(
-            "type" => "cnd"
-        );
-        $listings_content = SimplyRetsApiHelper::retrieveRetsListings( $listing_params );
-        $listings_content = "Sorry we could not find any open houses that match your search.";
-        return $listings_content;
-    }
-
 
     /**
      * Search Form Shortcode - [sr_search_form]

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -192,10 +192,22 @@ HTML;
     }
 
 
-    public static function sr_openhouses_shortcode($atts) {
-        $search_parameters = !is_array($atts) ? array() : $atts;
-        $listings_content = SimplyRetsApiHelper::retrieveOpenHousesResults($search_parameters);
-        return $listings_content;
+    public static function sr_openhouses_shortcode($atts = array()) {
+        $param_str = "?";
+
+        // Build a query string from the options provided on the short-code
+        if (is_array($atts)) {
+            foreach ($atts as $param=>$value) {
+                foreach (explode(";", $value) as $i=>$v) {
+                    $val = trim($v);
+                    $param_str .= "{$param}={$val}&";
+                }
+            }
+        }
+
+        $content = SimplyRetsApiHelper::retrieveOpenHousesResults($param_str);
+
+        return $content;
     }
 
 

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -190,27 +190,35 @@ class SrUtils {
     }
 
     public static function buildPaginationLinks( $pagination ) {
-        $pag = array(
-            'prev' => '',
-            'next' => ''
+        $prevPagination = $pagination["prev"];
+        $nextPagination = $pagination["next"];
+        $destination = $prevPagination && strpos($prevPagination, "/openhouses") ||
+                       $nextPagination && strpos($nextPagination, "/openhouses")
+                     ? "sr-openhouses"
+                     : "sr-search";
+
+        $siteUrl = get_home_url() . "/?sr-listings={$destination}&";
+        $paginationLinks = array('prev' => '', 'next' => '');
+        $apiUrls = array(
+            "https://api.simplyrets.com/properties?",
+            "https://api.simplyrets.com/openhouses?",
         );
-        $siteUrl = get_home_url() . '/?sr-listings=sr-search&';
 
-        if( $pagination['prev'] !== null && !empty($pagination['prev'] ) ) {
-            $previous = $pagination['prev'];
-            $prev = str_replace( 'https://api.simplyrets.com/properties?', $siteUrl, $previous );
+
+        if($prevPagination !== null && !empty($prevPagination)) {
+            $prev = str_replace($apiUrls, $siteUrl, $prevPagination);
             $prev_link = "<a href='{$prev}'>Prev</a>";
-            $pag['prev'] = $prev_link;
+            $paginationLinks['prev'] = $prev_link;
         }
 
-        if( $pagination['next'] !== null && !empty($pagination['next'] ) ) {
-            $nextLink = $pagination['next'];
-            $next = str_replace( 'https://api.simplyrets.com/properties?', $siteUrl, $nextLink );
-            $next_link = "| <a href='{$next}'>Next</a>";
-            $pag['next'] = $next_link;
+        if($nextPagination !== null && !empty($nextPagination)) {
+            $next = str_replace($apiUrls, $siteUrl, $nextPagination);
+            $maybe_pipe = $prevPagination && !empty($prevPagination) ? "|" : "";
+            $next_link = "{$maybe_pipe} <a href='{$next}'>Next</a>";
+            $paginationLinks['next'] = $next_link;
         }
 
-        return $pag;
+        return $paginationLinks;
     }
 
 

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -453,7 +453,7 @@ class SrMessages {
     public static function noResultsMsg($response) {
 
         $response = (array)$response;
-        if(isset($response['message'])) {
+        if(array_key_exists("message", $response)) {
             return (
                 '<br><p><strong>'
                 . $response['message']
@@ -470,23 +470,6 @@ class SrMessages {
         $noResultsMsg = "<br><p><strong>There are 0 listings that match this search. "
                          . "Please try to broaden your search criteria or feel free to try again later.</p></strong>";
         return $noResultsMsg;
-    }
-
-}
-
-
-
-class SrViews {
-
-    public static function listDateResults( $date ) {
-        $markup = <<<HTML
-            <li>
-                <span>Listed on $date</span>
-            </li>
-HTML;
-
-        return $markup;
-
     }
 
 }

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -20,6 +20,7 @@ require __DIR__.'/vendor/autoload.php';
 
 require_once( plugin_dir_path(__FILE__) . 'simply-rets-utils.php' );
 require_once( plugin_dir_path(__FILE__) . 'simply-rets-post-pages.php' );
+require_once( plugin_dir_path(__FILE__) . 'simply-rets-openhouses.php' );
 require_once( plugin_dir_path(__FILE__) . 'simply-rets-api-helper.php' );
 require_once( plugin_dir_path(__FILE__) . 'simply-rets-shortcode.php' );
 require_once( plugin_dir_path(__FILE__) . 'simply-rets-widgets.php' );

--- a/src/tests/bootstrap.php
+++ b/src/tests/bootstrap.php
@@ -6,9 +6,9 @@ if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
-	require dirname( __FILE__ ) . '/../simply-rets.php';
+    require dirname( __FILE__ ) . '/../simply-rets.php';
 }
+
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
-

--- a/src/tests/test-plugin.php
+++ b/src/tests/test-plugin.php
@@ -10,8 +10,9 @@ class SampleTest extends WP_UnitTestCase {
     }
 
     function testSingleListingRequest() {
-        $mlsid = '/123456';
-        $response = SimplyRetsApiHelper::srRequestUrlBuilder($mlsid, true);
-        $this->assertTrue( is_string( $response ) );
+        $params = '/123456';
+        $result = SimplyRetsApiHelper::srRequestUrlBuilder($params, "properties", true);
+
+        $this->assertTrue(is_string($result));
     }
 }


### PR DESCRIPTION
:gift: **READY!!!** :gift: 

Ref #111

This adds support for Open Houses in the SimplyRETS plugin, in a
couple of ways:

- `sr_openhouses` short-code
- Show open houses on listing details pages

### `[sr_openhouses]`
The `[sr_openhouses]` short-code allows you to add an open house
search to your website, just like the property search you get when
using `[sr_listings]`. There are still a few things to do here:

- [x] Support `/openhouses` search parameters on the short-code
- [x] Add admin option to select timezone for displaying open house times
  I think we need this, but it's tricky: some are UTC, some are already local, some aren't complete timestamps, etc

### Listing details pages
- [x] Show open house details on single listing pages
Showing open houses on listing details pages will be available as a
way to "call out" listings that have an upcoming open house. For users
with EnterpriseAccess, we can check for open houses when a listing
details page is viewed and show a banner at the top of the
page. We can also have an additional table at the bottom of the page
with the open house details.

---

### `[sr_openhouses]` screenshot
![image](https://user-images.githubusercontent.com/7034627/61155104-abcebf80-a4b5-11e9-81cc-afc442da6dd0.png)
