### PR TITLE
Support all API parameters on [sr_map_search] short-code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.7.2
+* ENHANCEMENT: Support all valid API parameters on [sr_map_search] short-code.
+
 ## 2.7.1
 * FIX: Properly escape remarks for HTML used in fance image gallery.
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -323,17 +323,17 @@ var getSearchFormValues = function() {
     // Merge the default parameters on the short-code with the
     // user-selected parameters. If the user hasn't selected a value
     // for an input, fallback to the default.
-    var params = Object.assign({}, {
-        q:        keyword,
-        type:     ptype,
+    var params = Object.assign({}, defParams, {
+        q:        keyword || defParams.q,
+        type:     ptype || defParams.type,
         sort:     sort,
-        minprice: minprice,
-        maxprice: maxprice,
-        minbeds:  minbeds,
-        maxbeds:  maxbeds,
-        minbaths: minbaths,
-        maxbaths: maxbaths,
-    }, defParams, { limit: defLimit })
+        minprice: minprice || defParams.minprice,
+        maxprice: maxprice || defParams.maxprice,
+        minbeds:  minbeds || defParams.minbeds,
+        maxbeds:  maxbeds || defParams.maxbeds,
+        minbaths: minbaths || defParams.minbaths,
+        maxbaths: maxbaths || defParams.maxbaths,
+    }, { limit: defLimit })
 
     var query = "?";
 
@@ -608,8 +608,10 @@ SimplyRETSMap.prototype.handleRequest = function(that, data) {
     if(listings.length < 1)
         that.offset = 0;
 
-    if(that.loaded === false)
+    if (!this.shape) {
         that.map.fitBounds(that.bounds);
+        that.map.setZoom(12)
+    }
 
     replaceListingMarkup(data.markup);
 
@@ -728,12 +730,13 @@ SimplyRETSMap.prototype.setDrawingManager = function() {
         },
         // markerOptions: { icon: 'custom/icon/here.png' },
         rectangleOptions: {
+            editable: true,
             fillOpacity: 0.1,
             fillColor: 'green',
             strokeColor: 'green'
         },
         polygonOptions: {
-            // editable: true
+            editable: true,
             fillOpacity: 0.1,
             fillColor: 'green',
             strokeColor: 'green'
@@ -745,6 +748,12 @@ SimplyRETSMap.prototype.setDrawingManager = function() {
     this.addEventListener(drawingManager, 'rectanglecomplete', function(overlay) {
         var q = that.handleRectangleDraw(that, overlay);
 
+        overlay.addListener("click", function() {
+            that.shape = null
+            that.bounds = []
+            overlay.setMap(null)
+        })
+
         that.sendRequest(q.points, q.query).done(function(data) {
             that.handleRequest(that, data);
         });
@@ -753,6 +762,12 @@ SimplyRETSMap.prototype.setDrawingManager = function() {
 
     this.addEventListener(drawingManager, 'polygoncomplete', function(overlay) {
         var q = that.handlePolygonDraw(that, overlay);
+
+        overlay.addListener("click", function() {
+            that.shape = null
+            that.bounds = []
+            overlay.setMap(null)
+        })
 
         that.sendRequest(q.points, q.query).done(function(data) {
             that.handleRequest(that, data);

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -421,7 +421,7 @@ SimplyRETSMap.prototype.getRectanglePoints = function(rec) {
     });
 
     this.bounds = bounds;
-    this.map.fitBounds(bounds);
+    this.map.fitBounds(this.bounds);
 
     return latLngs;
 }
@@ -459,7 +459,7 @@ SimplyRETSMap.prototype.getPolygonPoints = function(polygon) {
     });
 
     this.bounds = bounds;
-    this.map.fitBounds(bounds);
+    this.map.fitBounds(this.bounds);
 
     return latLngs;
 
@@ -610,7 +610,6 @@ SimplyRETSMap.prototype.handleRequest = function(that, data) {
 
     if (!this.shape) {
         that.map.fitBounds(that.bounds);
-        that.map.setZoom(12)
     }
 
     replaceListingMarkup(data.markup);
@@ -688,7 +687,6 @@ SimplyRETSMap.prototype.sendRequest = function(points, params, paginate) {
         }
     }
 
-    var limit  = this.limit;
     var offset = this.offset;
     var vendor = this.vendor
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.1.1
-Stable tag: 2.7.1
+Stable tag: 2.7.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.7.2 =
+* ENHANCEMENT: Support all valid API parameters on [sr_map_search] short-code.
 
 = 2.7.1 =
 * FIX: Properly escape remarks for HTML used in fance image gallery.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 5.1.1
+Tested up to: 5.2.2
 Stable tag: 2.7.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.7.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.7.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -209,7 +209,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.7.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.7.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/simply-rets-maps.php
+++ b/simply-rets-maps.php
@@ -168,7 +168,7 @@ HTML;
                 "vendor" => $vendor
             );
 
-            $req = SimplyRetsApiHelper::makeApiRequest("?".$_POST['parameters']);
+            $req = SimplyRetsApiHelper::makeApiRequest($_POST['parameters']);
             $con = SimplyRetsApiHelper::srResidentialResultsGenerator($req, $markup_opts);
 
             $response = array(

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -60,12 +60,22 @@ class SrShortcodes {
         $office_on_thumbnails = get_option('sr_office_on_thumbnails', false);
         $agent_on_thumbnails = get_option('sr_agent_on_thumbnails', false);
 
+        // Delete attributes that aren't API parameters
+        $default_parameters = array_diff_key($atts, [
+            "list_view" => true,
+            "search_form" => true
+        ]);
+
+        // JSON encode the default search parameters for the frontend.
+        $default_parameters_json = json_encode($default_parameters);
+
         $map_markup  = "<div id='sr-map-search'
                              data-api-key='{$gmaps_key}'
                              data-idx-img='{$idx_img}'
                              data-office-on-thumbnails='{$office_on_thumbnails}'
                              data-agent-on-thumbnails='{$agent_on_thumbnails}'
                              data-limit='{$limit}'
+                             data-default-parameters='{$default_parameters_json}'
                              data-vendor='{$vendor}'></div>";
 
         $list_markup = !empty($atts['list_view'])

--- a/simply-rets.php
+++ b/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.7.1
+Version: 2.7.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This updates the `[sr_map_search]` short-code to allow the user to
pass any valid API parameters to the short-code as default search
values. This allows users to do things like this:

```
[sr_map_search agent="1; 2" cities="1; 2" status="1; 2" ...etc]
```

Previously we only supported the `limit` parameter, making this
short-code much less useful for most of the common use-cases like
having a search page for a specific agent or area.

This needs a little bit of testing, but it's fairly straightforward:
you can add any attributes to the `[sr_map_search]` short-code, and
they will be sent to the API. The user CAN override default values by
using the search form. Some parameters can be specified on the
short-code but aren't visible in the search form. Those will always
use the default provided and cannot be overwritten by the user.