### PR TITLE
Support `idx` parameter and idx restricted addresses

### DIFF
--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -838,8 +838,9 @@ $_(document).ready(function() {
             var key = document.getElementById('sr-map-search').dataset.apiKey;
 
             // if google.maps doesn't exist - load it, then start map
-            var url = "https://maps.googleapis.com/maps/api/js?signed_in=true&libraries=drawing&callback=startMap" +
-                      "&key=" + key;
+            var url = "https://maps.googleapis.com/maps/api/js?"
+                    + "libraries=drawing&callback=startMap"
+                    + "&key=" + key;
 
             var script = document.createElement("script");
 

--- a/assets/js/simply-rets-client.js
+++ b/assets/js/simply-rets-client.js
@@ -684,6 +684,8 @@ SimplyRETSMap.prototype.sendRequest = function(points, params, paginate) {
         } else if(paginate === "prev") {
             scrollToAnchor('sr-search-wrapper');
             this.offset = Number(this.offset) - Number(this.limit);
+        } else if (paginate === "reset") {
+            this.offset = 0
         }
     }
 
@@ -801,7 +803,7 @@ SimplyRETSMap.prototype.initEventListeners = function() {
             points = params.points,
             query  = params.query;
 
-        that.sendRequest(points, query).done(function(data) {
+        that.sendRequest(points, query, "reset").done(function(data) {
             that.handleRequest(that, data);
         });
 

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -390,7 +390,7 @@ class SrAdminSettings {
             </table>
 
             <h3>Default IDX filter (Display rules)</h3>
-            <p>
+            <p style="margin-top:-10px">
                 <i>Note: </i>You can override this on any short-code by using
                 <a href="https://wordpress-demo.simplyrets.com/documentation">
                     the <code>idx</code> attribute.
@@ -398,6 +398,8 @@ class SrAdminSettings {
             </p>
             <table>
               <tbody>
+
+                <!-- idx=null (default) -->
                 <tr>
                   <td>
                     <label>
@@ -408,12 +410,15 @@ class SrAdminSettings {
                         Show listings approved for IDX display and IDX address display
                         <strong><i> (default)</i></strong>
                     </label>
-                    <br/>
-                    <small style="margin-left:25px">
-                        This is the default option and probably the one you want if you're unsure.
-                    </small>
+                    <div style="margin-left:25px; margin-bottom:10px; max-width:50%">
+                        <small>
+                            This is the default option and probably the one you want if you're unsure.
+                        </small>
+                    </div>
                   </td>
                 </tr>
+
+                <!-- idx=listing -->
                 <tr>
                   <td>
                     <label>
@@ -421,27 +426,31 @@ class SrAdminSettings {
                         '<input type="radio" id="sr_default_idx_filter" name="sr_default_idx_filter" value="listing" '
                         . checked("listing", get_option('sr_default_idx_filter'), false) . '/>'
                         ?>
-                        Show listings approved for IDX display and ignore IDX address display rules
+                        Show listings approved for IDX display, but ignore IDX address display rules
                     </label>
-                    <br/>
-                    <small style="margin-left:25px">
-                        Show listings approved for IDX display, but ignore any restrictions on displaying
-                        the address.
-                    </small>
-                    <br/>
+                    <div style="margin-left:25px; margin-bottom:-5px; max-width:50%">
+                        <small>
+                            Show listings approved for IDX display, but ignore any restrictions on
+                            displaying the address.
+                        </small>
+                    </div>
                     <p style="margin-left:25px">
-                        <strong>
-                            Suppressed address text replacement
-                        </strong>
+                        <strong>Suppressed address text replacement</strong>
                         <br/>
                         <small>
-                            Show this text in place of the address for IDX address display restricted listings.
+                            Show this text in place of the address for listings with IDX address restrictions.
                         </small>
                         <br/>
-                        <input type="text" name="sr_idx_address_display_text" value="<?php echo esc_attr( get_option("sr_idx_address_display_text") ); ?>" />
+                        <input
+                            type="text"
+                            name="sr_idx_address_display_text"
+                            value="<?php echo esc_attr( get_option("sr_idx_address_display_text") ); ?>"
+                        />
                     </p>
                   </td>
                 </tr>
+
+                <!-- idx=address -->
                 <tr>
                   <td>
                     <label>
@@ -449,18 +458,19 @@ class SrAdminSettings {
                         '<input type="radio" id="sr_default_idx_filter" name="sr_default_idx_filter" value="address" '
                         . checked("address", get_option('sr_default_idx_filter'), false) . '/>'
                         ?>
-                        Show listings NOT approved for IDX display, but are approved for IDX address display.
+                        Show listings approved for IDX address display, but ignore IDX listing display restrictions.
                     </label>
-                    <br/>
-                    <small style="margin-left:25px">
-                        Show listings that are NOT approved for IDX display, but are approved for IDX address display.
-                    </small>
-                    <br/>
-                    <small style="margin-left:25px">
-                        Check the display rules and requirements with your data feed provider before using this option.
-                    </small>
+                    <div style="margin-left:25px; margin-bottom:10px; max-width:50%">
+                        <small>
+                            Show listings that are NOT approved for IDX display, but ARE approved for
+                            IDX address display. <strong>Use this option carefully</strong> and check
+                            the display requirements with your data feed provider.
+                        </small>
+                    </div>
                   </td>
                 </tr>
+
+                <!-- idx=ignore -->
                 <tr>
                   <td>
                     <label>
@@ -470,12 +480,16 @@ class SrAdminSettings {
                         ?>
                         Ignore all IDX restrictions
                     </label>
-                    <br/>
-                    <small style="margin-left:25px">
-                        This is the default option and probably the one you want if you're unsure.
-                    </small>
+                    <div style="margin-left:25px; margin-bottom:0px; max-width:50%">
+                        <small>
+                            Show all listings regardless of any IDX restrictions.
+                            <strong>USE CAUTION</strong> enabling this on public sites and check the display
+                            requirements for your data feed provider or MLS.
+                        </small>
+                    </div>
                   </td>
                 </tr>
+
               </tbody>
             </table>
           </div>

--- a/simply-rets-admin.php
+++ b/simply-rets-admin.php
@@ -49,6 +49,12 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
       register_setting('sr_admin_settings', 'sr_show_mls_trademark_symbol');
       register_setting('sr_admin_settings', 'sr_disable_listing_details_map');
+      register_setting('sr_admin_settings', 'sr_default_idx_filter', array(
+          "default" => "null"
+      ));
+      register_setting('sr_admin_settings', 'sr_idx_address_display_text', array(
+          "default" => "Undisclosed address"
+      ));
   }
 
   public static function adminMessages () {
@@ -378,6 +384,96 @@ class SrAdminSettings {
                       ?>
                         Show trademark symbol next to MLS text (eg, "MLS®")
                     </label>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>Default IDX filter (Display rules)</h3>
+            <p>
+                <i>Note: </i>You can override this on any short-code by using
+                <a href="https://wordpress-demo.simplyrets.com/documentation">
+                    the <code>idx</code> attribute.
+                </a>
+            </p>
+            <table>
+              <tbody>
+                <tr>
+                  <td>
+                    <label>
+                        <?php echo
+                        '<input type="radio" id="sr_default_idx_filter" name="sr_default_idx_filter" value="null" '
+                        . checked("null", get_option('sr_default_idx_filter'), false) . '/>'
+                        ?>
+                        Show listings approved for IDX display and IDX address display
+                        <strong><i> (default)</i></strong>
+                    </label>
+                    <br/>
+                    <small style="margin-left:25px">
+                        This is the default option and probably the one you want if you're unsure.
+                    </small>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <label>
+                        <?php echo
+                        '<input type="radio" id="sr_default_idx_filter" name="sr_default_idx_filter" value="listing" '
+                        . checked("listing", get_option('sr_default_idx_filter'), false) . '/>'
+                        ?>
+                        Show listings approved for IDX display and ignore IDX address display rules
+                    </label>
+                    <br/>
+                    <small style="margin-left:25px">
+                        Show listings approved for IDX display, but ignore any restrictions on displaying
+                        the address.
+                    </small>
+                    <br/>
+                    <p style="margin-left:25px">
+                        <strong>
+                            Suppressed address text replacement
+                        </strong>
+                        <br/>
+                        <small>
+                            Show this text in place of the address for IDX address display restricted listings.
+                        </small>
+                        <br/>
+                        <input type="text" name="sr_idx_address_display_text" value="<?php echo esc_attr( get_option("sr_idx_address_display_text") ); ?>" />
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <label>
+                        <?php echo
+                        '<input type="radio" id="sr_default_idx_filter" name="sr_default_idx_filter" value="address" '
+                        . checked("address", get_option('sr_default_idx_filter'), false) . '/>'
+                        ?>
+                        Show listings NOT approved for IDX display, but are approved for IDX address display.
+                    </label>
+                    <br/>
+                    <small style="margin-left:25px">
+                        Show listings that are NOT approved for IDX display, but are approved for IDX address display.
+                    </small>
+                    <br/>
+                    <small style="margin-left:25px">
+                        Check the display rules and requirements with your data feed provider before using this option.
+                    </small>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <label>
+                        <?php echo
+                        '<input type="radio" id="sr_default_idx_filter" name="sr_default_idx_filter" value="ignore" '
+                        . checked("ignore", get_option('sr_default_idx_filter'), false) . '/>'
+                        ?>
+                        Ignore all IDX restrictions
+                    </label>
+                    <br/>
+                    <small style="margin-left:25px">
+                        This is the default option and probably the one you want if you're unsure.
+                    </small>
                   </td>
                 </tr>
               </tbody>

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -1594,7 +1594,7 @@ HTML;
             $listing_USD   = '$' . number_format( $listing_price );
 
             // widget title
-            $address = $listing->address->full;
+            $address = SrUtils::buildFullAddressString($listing);
 
             // widget photo
             $listingPhotos = $listing->photos;

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -80,7 +80,7 @@ class SimplyRetsApiHelper {
 
         // Parse params into an array
         $params_arr = !is_array($params)
-                    ? SrUtils::proper_parse_str(ltrim($params, "?"))
+                    ? SrUtils::proper_parse_str(ltrim(urldecode($params), "?"))
                     : $params;
 
         // Apply the default `idx` setting if not provided
@@ -90,7 +90,7 @@ class SimplyRetsApiHelper {
         }
 
         // Build query string from parameters
-        $params_str = http_build_query($params_arr);
+        $params_str = SrUtils::proper_build_query($params_arr);
         $request_url = $base_url . "?" . $params_str;
 
         return $request_url;

--- a/simply-rets-api-helper.php
+++ b/simply-rets-api-helper.php
@@ -560,6 +560,9 @@ HTML;
         // Get the text "MLS"
         $MLS_text = SrUtils::mkMLSText();
 
+        // Display permissions
+        $internetAddressDisplay = $listing->internetAddressDisplay;
+
         /**
          * Get the listing status to show. Note that if the
          * sr_show_mls_status_text admin option is set to true, we
@@ -612,10 +615,10 @@ HTML;
         $listing_fireplaces = $listing->property->fireplaces;
         $fireplaces = SimplyRetsApiHelper::srDetailsTable($listing_fireplaces, "Fireplaces");
         // Long
-        $listing_longitude = $listing->geo->lng;
+        $listing_longitude = $internetAddressDisplay === FALSE ? NULL : $listing->geo->lng;
         $geo_longitude = SimplyRetsApiHelper::srDetailsTable($listing_longitude, "Longitude");
         // Long
-        $listing_lat = $listing->geo->lat;
+        $listing_lat = $internetAddressDisplay === FALSE ? NULL : $listing->geo->lat;
         $geo_latitude = SimplyRetsApiHelper::srDetailsTable($listing_lat, "Latitude");
         // County
         $listing_county = $listing->geo->county;
@@ -649,7 +652,7 @@ HTML;
         $subdivision = SimplyRetsApiHelper::srDetailsTable($listing_subdivision, "Subdivision");
         // unit
         $listing_unit_value = $listing->address->unit;
-        $listing_unit = $listing->internetAddressDisplay === false ? null : $listing_unit_value;
+        $listing_unit = $internetAddressDisplay === FALSE ? NULL : $listing_unit_value;
         $unit = SimplyRetsApiHelper::srDetailsTable($listing_unit, "Unit");
         // int/ext features
         $listing_interiorFeatures = $listing->property->interiorFeatures;
@@ -1336,6 +1339,7 @@ HTML;
             $subdivision        = $listing->property->subdivision;
             $style              = $listing->property->style;
             $yearBuilt          = $listing->property->yearBuilt;
+            $internetAddressDisplay = $listing->internetAddressDisplay;
 
             /**
              * Listing status to show. This may return a statusText.
@@ -1383,7 +1387,7 @@ HTML;
             /************************************************
              * Make our map marker for this listing
              */
-            if( $lat && $lng ) {
+            if($lat && $lng && $internetAddressDisplay !== FALSE) {
                 $marker = SrSearchMap::markerWithDefaults();
                 $iw     = SrSearchMap::infoWindowWithDefaults();
                 $iwCont = SrSearchMap::infoWindowMarkup(

--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -185,6 +185,7 @@ class SimplyRetsCustomPostPages {
         $vars[] = "sr_agent";
         $vars[] = "sr_brokers";
         $vars[] = "sr_sort";
+        $vars[] = "sr_idx";
         $vars[] = "water";
         // post type
         $vars[] = "sr-listings";
@@ -582,12 +583,12 @@ class SimplyRetsCustomPostPages {
             $lotsize   = get_query_var( 'sr_lotsize', '' );
             $area      = get_query_var( 'sr_area', '' );
             $sort      = get_query_var( 'sr_sort', '' );
+            $idx       = get_query_var( 'sr_idx', '' );
             /** multi mls */
             $vendor    = get_query_var('sr_vendor', '');
 
             $map_position = get_query_var('sr_map_position',
                                           get_option('sr_search_map_position'));
-
 
             /**
              * Format the 'type' parameter.
@@ -788,6 +789,7 @@ class SimplyRetsCustomPostPages {
                 "minprice"  => $minprice,
                 "maxprice"  => $maxprice,
                 "water"     => $water,
+                "idx"       => $idx,
 
                 /** Pagination */
                 "limit"     => $limit,

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -424,10 +424,9 @@ HTML;
         if($config_type === '') {
             $config_type = isset($_GET['sr_ptype']) ? $_GET['sr_ptype'] : '';
         }
-        if(empty($vendor) && $singleVendor === true) {
+        if(empty($vendor) && $singleVendor === true && !empty($availableVendors)) {
             $vendor = $availableVendors[0];
         }
-        $vendorOptions = "_$vendor";
 
         /** User Facing Parameters */
         $minbeds    = array_key_exists('minbeds',  $atts) ? $atts['minbeds']  : '';

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -51,6 +51,7 @@ class SrShortcodes {
         $brokers  = isset($atts['brokers']) ? $atts['brokers'] : '';
         $agent    = isset($atts['agent'])   ? $atts['agent']   : '';
         $limit    = isset($atts['limit'])   ? $atts['limit'] : '25';
+        $idx      = isset($atts['idx'])     ? $atts['idx'] : '';
         $type_att = isset($atts['type'])    ? $atts['type'] : '';
 
         $content     = "";
@@ -152,6 +153,7 @@ class SrShortcodes {
                       <input type="hidden" name="sr_vendor"  value="$vendor" />
                       <input type="hidden" name="sr_brokers" value="$brokers" />
                       <input type="hidden" name="sr_agent"   value="$agent" />
+                      <input type="hidden" name="sr_idx"     value="$idx" />
                       <input type="hidden" name="limit"      value="$limit" />
 
                       <div>
@@ -413,6 +415,7 @@ HTML;
         $brokers = isset($atts['brokers']) ? $atts['brokers'] : '';
         $agent   = isset($atts['agent'])   ? $atts['agent']   : '';
         $water   = isset($atts['water'])   ? $atts['water']   : '';
+        $idx     = isset($atts['idx'])   ? $atts['idx']       : '';
         $limit   = isset($atts['limit'])   ? $atts['limit']   : '';
         $config_type = isset($atts['type']) ? $atts['type']   : '';
         $subtype = isset($atts['subtype']) ? $atts['subtype'] : '';
@@ -667,6 +670,7 @@ HTML;
                 </div>
 
                 <input type="hidden" name="water"   value="<?php echo $water; ?>"  />
+                <input type="hidden" name="sr_idx"   value="<?php echo $idx; ?>"  />
                 <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
                 <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
                 <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
@@ -756,6 +760,7 @@ HTML;
             </div>
 
             <input type="hidden" name="water"   value="<?php echo $water; ?>"  />
+            <input type="hidden" name="sr_idx"   value="<?php echo $idx; ?>"  />
             <input type="hidden" name="sr_vendor"  value="<?php echo $vendor; ?>"  />
             <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
             <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -244,6 +244,7 @@ HTML;
             /**
              * Neighborhoods filter is being used - check for multiple values and build query accordingly
              */
+            $neighborhoods_string = "";
             if( isset( $listing_params['neighborhoods'] ) && !empty( $listing_params['neighborhoods'] ) ) {
                 $neighborhoods = explode( ';', $listing_params['neighborhoods'] );
                 foreach( $neighborhoods as $key => $neighborhood ) {
@@ -253,6 +254,7 @@ HTML;
                 $neighborhoods_string = str_replace(' ', '%20', $neighborhoods_string );
             }
 
+            $cities_string = "";
             if( isset( $listing_params['cities'] ) && !empty( $listing_params['cities'] ) ) {
                 $cities = explode( ';', $listing_params['cities'] );
                 foreach( $cities as $key => $city ) {
@@ -262,6 +264,7 @@ HTML;
                 $cities_string = str_replace(' ', '%20', $cities_string );
             }
 
+            $agents_string = "";
             if( isset( $listing_params['agent'] ) && !empty( $listing_params['agent'] ) ) {
                 $agents = explode( ';', $listing_params['agent'] );
                 foreach( $agents as $key => $agent ) {
@@ -271,6 +274,7 @@ HTML;
                 $agents_string = str_replace(' ', '%20', $agents_string );
             }
 
+            $ptypes_string = "";
             if( isset( $listing_params['type'] ) && !empty( $listing_params['type'] ) ) {
                 $ptypes = explode( ';', $listing_params['type'] );
                 foreach($ptypes as $key => $ptype) {
@@ -280,6 +284,7 @@ HTML;
                 $ptypes_string = str_replace(' ', '%20', $ptypes_string );
             }
 
+            $subtypes_string = "";
             if(isset($listing_params['subtype']) && !empty($listing_params['subtype'])) {
                 $subtypes = explode(';', $listing_params['subtype']);
                 foreach($subtypes as $key => $subtype) {
@@ -289,6 +294,7 @@ HTML;
                 $subtypes_string = str_replace(' ', '%20', $subtypes_string);
             }
 
+            $postalcodes_string = "";
             if( isset( $listing_params['postalcodes'] ) && !empty( $listing_params['postalcodes'] ) ) {
                 $postalcodes = explode( ';', $listing_params['postalcodes'] );
                 foreach( $postalcodes as $key => $postalcode  ) {
@@ -298,6 +304,7 @@ HTML;
                 $postalcodes_string = str_replace(' ', '%20', $postalcodes_string );
             }
 
+            $counties_string = "";
             if( isset( $listing_params['counties'] ) && !empty( $listing_params['counties'] ) ) {
                 $counties = explode( ';', $listing_params['counties'] );
                 foreach( $counties as $key => $county ) {
@@ -307,6 +314,7 @@ HTML;
                 $counties_string = str_replace(' ', '%20', $counties_string );
             }
 
+            $q_string = "";
             if( isset( $listing_params['q'] ) && !empty( $listing_params['q'] ) ) {
                 $keywords = explode( ';', $listing_params['q'] );
                 foreach( $keywords as $key => $keyword ) {
@@ -319,6 +327,7 @@ HTML;
             /**
              * Multiple statuses
              */
+            $statuses_string = "";
             if( isset( $listing_params['status'] ) && !empty( $listing_params['status'] ) ) {
 
                 $statuses = explode( ';', $listing_params['status'] );
@@ -334,6 +343,7 @@ HTML;
             /**
              * Build a regular query string for everything else
              */
+            $params_string = "";
             foreach( $listing_params as $key => $value ) {
                 // Skip params that support multiple
                 if( $key !== 'postalcodes'

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -233,6 +233,10 @@ class SrUtils {
 
         foreach ($pairs as $i) {
 
+            if (empty($i)) {
+                continue;
+            }
+
             list($name,$value) = explode('=', $i, 2);
 
             if( isset($arr[$name]) ) {

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -104,6 +104,17 @@ class SrUtils {
      */
     public static function buildFullAddressString($listing) {
 
+        $idxAddress = $listing->internetAddressDisplay;
+        $idxListing = $listing->internetEntireListingDisplay;
+
+        if ($idxAddress === false) {
+            $idxAddressReplacement = get_option(
+                "sr_idx_address_display_text",
+                "Undisclosed address"
+            );
+            return $idxAddressReplacement;
+        }
+
         $city = $listing->address->city;
         $state = $listing->address->state;
         $zip = $listing->address->postalCode;
@@ -430,7 +441,7 @@ class SrMessages {
     public static function noResultsMsg($response) {
 
         $response = (array)$response;
-        if($response['message']) {
+        if(isset($response['message'])) {
             return (
                 '<br><p><strong>'
                 . $response['message']

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -105,20 +105,15 @@ class SrUtils {
     public static function buildFullAddressString($listing) {
 
         $idxAddress = $listing->internetAddressDisplay;
-        $idxListing = $listing->internetEntireListingDisplay;
-
-        if ($idxAddress === false) {
-            $idxAddressReplacement = get_option(
-                "sr_idx_address_display_text",
-                "Undisclosed address"
-            );
-            return $idxAddressReplacement;
-        }
+        $address = $idxAddress === false
+                 ? $idxAddressReplacement = get_option(
+                     "sr_idx_address_display_text",
+                     "Undisclosed address"
+                 ) : $listing->address->full;
 
         $city = $listing->address->city;
         $state = $listing->address->state;
         $zip = $listing->address->postalCode;
-        $address = $listing->address->full;
 
         // A listing might have a null address if a flag like "Display
         // address" is set to false. This just removes the comma in

--- a/simply-rets-utils.php
+++ b/simply-rets-utils.php
@@ -255,6 +255,19 @@ class SrUtils {
         return $arr;
     }
 
+    /**
+     * Build a query string from an array of parameters. NOTE: This
+     * function REMOVES array indexes ([0]) from parameters names that
+     * are specified multiple times. For example:
+     *
+     * http_build_query: q[0]=first&q[1]=second
+     * proper_build_query: q=first&q=second
+     */
+    public static function proper_build_query($params = array()) {
+        $array_indice_regex = "/%5B(?:[0-9]|[1-9][0-9]+)%5D=/";
+        $query_str = http_build_query($params);
+        return preg_replace($array_indice_regex, "=", $query_str);
+    }
 
     public static function ordinalSuffix($number) {
         $ends = array('th','st','nd','rd','th','th','th','th','th','th');

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -11,7 +11,7 @@ class SampleTest extends WP_UnitTestCase {
 
     function testSingleListingRequest() {
         $mlsid = '/123456';
-        $response = SimplyRetsApiHelper::srRequestUrlBuilder( $mlsid );
+        $response = SimplyRetsApiHelper::srRequestUrlBuilder($mlsid, true);
         $this->assertTrue( is_string( $response ) );
     }
 }

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -8,9 +8,9 @@ class SampleTest extends WP_UnitTestCase {
     function testCreatePost() {
         $this->factory->post->create_many( 5 );
     }
-    
+
     function testSingleListingRequest() {
-        $mlsid = '123456';
+        $mlsid = '/123456';
         $response = SimplyRetsApiHelper::srRequestUrlBuilder( $mlsid );
         $this->assertTrue( is_string( $response ) );
     }


### PR DESCRIPTION
Add support for the (coming soon) `idx` API parameter. The `idx` parameter allows users to specify which listings to show based on IDX restrictions.

**Overall tasks**
- [x] Add admin option to support a global/default IDX filter
- [x] Support `idx` attribute on each short-code to override global setting:
  - [x] `[sr_search_form]`
  - [x] `[sr_listings]`
  - [x] `[sr_map_search]`
  - [x] `[sr_listings_slider]`
  - [x] SimplyRETS widgets
- [x] Add admin option to replace IDX restricted addresses display text

**Finalizing**
- [x] Merge new API fields and search parameters (`ready`)
- [x] Code review and testing
- [ ] Tag version (`2.7.3`)
- [ ] Release to WordPress plugin directory