### PR TITLE
Support openhouses on multi-vendor accounts

### DIFF
--- a/src/assets/css/simply-rets-client.css
+++ b/src/assets/css/simply-rets-client.css
@@ -338,6 +338,7 @@ the class or the id, depending on what you need.
 .sr-listing-openhouses-banner-item {
     display: inline-block;
     width: 25%;
+    padding-bottom: 5px;
 }
 
 /*

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -21,11 +21,13 @@ class SimplyRetsApiHelper {
     }
 
     public static function retrieveOpenHousesResults($params, $settings = NULL) {
-        $request_url = SimplyRetsApiHelper::srRequestUrlBuilder($params, "openhouses");
-        $response = SimplyRetsApiHelper::srApiRequest($request_url);
-        $response_markup  = SimplyRetsOpenHouses::openHousesSearchResults($response);
+        $api_url = SimplyRetsApiHelper::srRequestUrlBuilder($params, "openhouses");
+        $api_response = SimplyRetsApiHelper::srApiRequest($api_url);
 
-        return $response_markup;
+        return SimplyRetsOpenHouses::openHousesSearchResults(
+            $api_response,
+            $settings
+        );
     }
 
     public static function retrieveListingDetails( $listing_id ) {

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1043,9 +1043,7 @@ HTML;
         );
 
         $upcoming_openhouses = count($openhouses);
-        $next_openhouses = $upcoming_openhouses > 0
-                         ? array_slice($openhouses, 0, 4)
-                         : NULL;
+        $next_openhouses = $upcoming_openhouses > 0 ? $openhouses : NULL;
 
         $next_openhouses_banner = "";
         if ($next_openhouses) {

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -194,6 +194,7 @@ HTML;
 
     public static function sr_openhouses_shortcode($atts = array()) {
         $param_str = "?";
+        $settings = array();
 
         // Build a query string from the options provided on the short-code
         if (is_array($atts)) {
@@ -202,12 +203,18 @@ HTML;
                     $val = trim($v);
                     $param_str .= "{$param}={$val}&";
                 }
+
+                // Pass certain settings through as an array
+                if ($param === "vendor") {
+                    $settings["vendor"] = $value;
+                }
             }
         }
 
-        $content = SimplyRetsApiHelper::retrieveOpenHousesResults($param_str);
-
-        return $content;
+        return SimplyRetsApiHelper::retrieveOpenHousesResults(
+            $param_str,
+            $settings
+        );
     }
 
 


### PR DESCRIPTION
This passes any `vendor` parameters around the open house code to ensure API requests for open houses are made with a vendor ID for multi-vendor API credentials.

- [x] Support on `[sr_openhouses]` search results
- [x] Support on listing details pages when fetching open houses