### PR TITLE
Handle errors when requesting open houses on listing detail pages

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1038,15 +1038,15 @@ HTML;
         /**
          * If user has EnterpriseAccess, check for open houses
          */
-        $openhouses = SimplyRetsOpenHouses::getOpenHousesByListingId(
+        $openhouses = $has_openhouses ? SimplyRetsOpenHouses::getOpenHousesByListingId(
             $listing->listingId
-        );
+        ) : array();
 
         $upcoming_openhouses = count($openhouses);
         $next_openhouses = $upcoming_openhouses > 0 ? $openhouses : NULL;
 
         $next_openhouses_banner = "";
-        if ($next_openhouses) {
+        if ($has_openhouses && $next_openhouses) {
 
             $next_openhouses_details = "";
             $next_openhouses_item_class = "sr-listing-openhouses-banner-item";

--- a/src/simply-rets-openhouses.php
+++ b/src/simply-rets-openhouses.php
@@ -24,8 +24,13 @@ class SimplyRetsOpenHouses {
         ]);
 
         $response = SimplyRetsApiHelper::makeApiRequest($params, "openhouses");
+        $data = $response["response"];
 
-        return $response["response"];
+        if (!is_array($data) && property_exists($data, "error")) {
+            return array();
+        } else {
+            return $data;
+        }
     }
 
     public static function getOpenHouseDateTimes($openhouse) {


### PR DESCRIPTION
Fixes an issue where "Upcoming open houses" are shown on listing detail pages for non-Enterprise users.