### PR TITLE
Handle "/" characters in single listing page URLs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 # Changelog
 
+## 2.8.3
+* FIX: Handle "/" characters in single listing page URLs.
+
 ## 2.8.2
-* FIX: Add error handling for openhouses API requests
+* FIX: Add error handling for openhouses API requests.
 
 ## 2.8.1
 * ENHANCEMENT: Add support for open houses short-code and search results.

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.3.0
-Stable tag: 2.8.2
+Stable tag: 2.8.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.8.3 =
+* FIX: Handle "/" characters in single listing page URLs.
 
 = 2.8.2 =
 * FIX: Add error handling for openhouses API requests

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -119,7 +119,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.8.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.8.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -240,7 +240,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.8.2 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.8.3 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -941,13 +941,20 @@ class SimplyRetsCustomPostPages {
             (!empty($wpq['sr-listings']) AND $wpq['sr-listings'] == "sr-single")
         ) {
 
-            $post_id    = urldecode(get_query_var( 'listing_id', '' ));
-            $post_addr  = urldecode(get_query_var( 'listing_title', '' ));
-            $post_price = urldecode(get_query_var( 'listing_price', '' ));
+            $post_id    = urldecode(get_query_var('listing_id', ''));
+            $post_price = urldecode(get_query_var('listing_price', ''));
+            $post_addr  = SrUtils::decodeStringForUrl(
+                urldecode(get_query_var('listing_title', ''))
+            );
 
             $listing_USD = $post_price == '' ? '' : '$' . number_format( $post_price );
             $title_normalize = "background-color:transparent;padding:0px;";
-            $post_title = "{$post_addr} <span style='{$title_normalize}'><small><i> {$listing_USD}</i></small></span>";
+            $post_title = "{$post_addr} "
+                        . "<span style='{$title_normalize}'>"
+                        . "  <small>"
+                        . "    <i> {$listing_USD}</i>"
+                        . "  </small>"
+                        . "</span>";
 
             $post = (object)array(
                 "ID"             => $post_id,

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -124,6 +124,21 @@ class SrUtils {
     }
 
     /**
+     * Encode specific characters in a string to work in a URL. For
+     * example, a `/` character cannot be normally encoded as %2F
+     * because Apache url decodes the string and treats it as a path
+     * separator. See: https://stackoverflow.com/a/3235361/3464723
+     */
+    public static function encodeStringForUrl($str) {
+        return str_replace("/", "_", $str);
+    }
+
+    // Decode a string encoded with `encodeStringForUrl`
+    public static function decodeStringForUrl($str) {
+        return str_replace("_", "/", $str);
+    }
+
+    /**
      * Builds a link to a listings' details page. Used in search results.
      */
     public static function buildDetailsLink($listing, $params = array()) {
@@ -150,8 +165,11 @@ class SrUtils {
         $listing_city = $listing->address->city;
         $listing_state = $listing->address->state;
         $listing_zip = $listing->address->postalCode;
+
         $listing_address = $listing->address->full;
-        $listing_address_full = SrUtils::buildFullAddressString($listing);
+        $listing_address_full = SrUtils::encodeStringForUrl(
+            SrUtils::buildFullAddressString($listing)
+        );
 
         if($prettify && $custom_permalink_struct === "pretty_extra") {
 

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.8.2
+Version: 2.8.3
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This adds handling for "/" characters that appear in within the
address of a link to the litsing details pages. We have to create a
special way of handling these because normal URL encoding of
`/`->`%2F` is not supported, by default, in Apache.

Right now the proposed change converts a `/` to `_`, when creating a
link to a details page, and then converts it back from `_` -> `/` when
using this part of the link to render the page title.

The `_` seems like a fairly uncommon character in address strings, so
I thought it would be a safe bet for now. The other consideration for
using a simple character (and not, say `/`->`<slash>`) is that we want
to the address in the URL bar to still be fairly read-able.

See: https://stackoverflow.com/a/3235361/3464723
We aren't able to modify the Apache configuration from within WordPress: http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes

---

Ideally, down the road as we continue improving the plugin, we don't
need to rely on the URL to create the page title within WordPress, and
we can simply used data fetched from the API. But the way things are
set up right now with "dynamic post content", this is how we have to
do it. Although, I do see there are better ways of handling dynamic
posts within WordPress that we should work towards.