### PR TITLE
Don't save null post meta

### DIFF
--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -405,6 +405,7 @@ class SimplyRetsCustomPostPages {
         } else {
             $current_nonce = NULL;
         }
+
         $is_autosaving = wp_is_post_autosave( $post_id );
         $is_revision   = wp_is_post_revision( $post_id );
         $valid_nonce   = ( isset( $current_nonce ) && wp_verify_nonce( $current_nonce, basename( __FILE__ ) ) ) ? 'true' : 'false';
@@ -415,10 +416,8 @@ class SimplyRetsCustomPostPages {
 
         if( isset($_POST['sr_filters']) ) {
             $sr_filters = $_POST['sr_filters'];
-        } else {
-            $sr_filters = NULL;
+            return update_post_meta( $post_id, 'sr_filters', $sr_filters );
         }
-        update_post_meta( $post_id, 'sr_filters', $sr_filters );
     }
 
     public static function postTemplateMetaBoxMarkup( $post ) {
@@ -454,6 +453,7 @@ class SimplyRetsCustomPostPages {
         } else {
             $current_nonce = NULL;
         }
+
         $is_autosaving = wp_is_post_autosave( $post_id );
         $is_revision   = wp_is_post_revision( $post_id );
         $valid_nonce   = ( isset( $current_nonce ) && wp_verify_nonce( $current_nonce, basename( __FILE__ ) ) ) ? 'true' : 'false';
@@ -464,10 +464,8 @@ class SimplyRetsCustomPostPages {
 
         if( isset($_POST['sr_page_template']) ) {
             $sr_page_template = $_POST['sr_page_template'];
-        } else {
-            $sr_page_template = NULL;
+            return update_post_meta( $post_id, 'sr_page_template', $sr_page_template );
         }
-        update_post_meta( $post_id, 'sr_page_template', $sr_page_template );
     }
 
 


### PR DESCRIPTION
Don't save null postmeta for `sr_filters` and `sr_page_template`.

Currently we have an issue where `sr_filters` and `sr_page_template` columns are saved as `NULL` in the `wp_postmeta` table for every post. This change ensures that those columns are only created when `sr_filters` or `sr_page_template` is non-null, instead of creating unnecessary rows in the database.