### PR TITLE
Use consistent logic when displaying listings bathrooms summary

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -814,14 +814,11 @@ HTML;
 
 
         // Determine the best field to show in the primary-details section
-        $primary_baths = "";
-        if(is_numeric($listing_bathsTotal)) {
-            $primary_baths = $listing_bathsTotal + 0; // strips extraneous decimals
-        } elseif(!empty($listing_bathsFull)) {
-            $primary_baths = $listing_bathsFull;
-        } else {
-            $primary_baths = 'n/a';
-        }
+        $primary_baths = SrListing::getBathroomsDisplay(
+            $listing_bathsTotal,
+            $listing_bathsFull,
+            true
+        );
 
 
         if( $listing_bedrooms == null || $listing_bedrooms == "" ) {
@@ -1189,7 +1186,7 @@ HTML;
                 <h3>$listing_bedrooms <small>Beds</small></h3>
               </div>
               <div class="sr-detail" id="sr-primary-details-baths">
-                <h3>$primary_baths<small> Baths</small></h3>
+                <h3>$primary_baths</h3>
               </div>
               <div class="sr-detail" id="sr-primary-details-size">
                 <h3>$area <small class="sr-listing-area-sqft">SqFt</small></h3>
@@ -1511,21 +1508,10 @@ HTML;
                 $yearMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($subdivision, "");
             }
 
-
-            /**
-             * Get the 'best' number for the total baths.
-             * Prioritize 'bathrooms' (eg, total baths) over
-             * bathsFull, and only fallback to bathsFull if bathrooms
-             * is not available.
-             */
-            $bathsMarkup;
-            if(is_numeric($bathsTotal)) {
-                $total_baths = $bathsTotal + 0; // strips extraneous decimals
-                $bathsMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($total_baths, 'Bath');
-            } else {
-                $bathsMarkup = SimplyRetsApiHelper::resultDataColumnMarkup($bathsFull, 'Full Baths');
-            }
-
+            $bathrooms_display = SrListing::getBathroomsDisplay(
+                $bathsTotal,
+                $bathsFull
+            );
 
             // append markup for this listing to the content
             $resultsMarkup .= <<<HTML
@@ -1551,7 +1537,7 @@ HTML;
                     </ul>
                     <ul class="sr-data-column">
                       $bedsMarkup
-                      $bathsMarkup
+                      <li>$bathrooms_display</li>
                       $areaMarkup
                     </ul>
                   </div>
@@ -1654,10 +1640,10 @@ HTML;
                 $bedrooms = 0;
             }
 
-            $bathsFull   = $listing->property->bathsFull;
-            if( $bathsFull == null || $bathsFull == "" ) {
-                $bathsFull = 0;
-            }
+            $bathrooms_display = SrListing::getBathroomsDisplay(
+                $listing->property->bathrooms,
+                $listing->property->bathsFull
+            );
 
             $mls_status = SrListing::listingStatus($listing);
 
@@ -1700,7 +1686,7 @@ HTML;
                 </a>
                 <div class="sr-listing-wdgt-primary">
                   <div id="sr-listing-wdgt-details">
-                    <span>$bedrooms Bed | $bathsFull Bath | $mls_status </span>
+                    <span>$bedrooms Bed | $bathrooms_display | $mls_status </span>
                   </div>
                   <hr>
                   <div id="sr-listing-wdgt-remarks">
@@ -1838,21 +1824,12 @@ HTML;
                 $photo = str_replace("\\", "", $photo);
             }
 
-            /**
-             * Get the best number for 'baths'. Prioritize `bathrooms`
-             * over `bathsFull`, and only use `bathsFull` if
-             * `bathrooms` is not available. This is the same display
-             * logic used in the [sr_listings] short-code.
-             */
             $bathsFull  = $l->property->bathsFull;
             $bathsTotal = $l->property->bathrooms;
-
-            $baths = 0;
-            if (is_numeric($bathsTotal)) {
-                $baths = $bathsTotal + 0; // Strips extraneous decimals
-            } else {
-                $baths = $bathsFull;
-            }
+            $bathrooms_display = SrListing::getBathroomsDisplay(
+                $bathsTotal,
+                $bathsFull
+            );
 
             /**
              * Show listing brokerage, if applicable
@@ -1869,7 +1846,7 @@ HTML;
                   <a href="$link">
                     <h4 class="sr-listing-slider-item-address">$address <small>$priceUSD</small></h4>
                   </a>
-                  <p class="sr-listing-slider-item-specs">$beds bed / $baths bath / $area SqFt</p>
+                  <p class="sr-listing-slider-item-specs">$beds Bed / $bathrooms_display / $area SqFt</p>
                   <p class="sr-listing-slider-item-specs">$compliance_markup</p>
                 </div>
 HTML;

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1785,7 +1785,7 @@ HTML;
 
     public static function srListingSliderGenerator( $response, $settings ) {
         $listings = $response['response'];
-        $inner;
+        $inner = "";
 
         $last_update = $response['lastUpdate'];
         $disclaimer = SrUtils::mkDisclaimerText($last_update);
@@ -1859,7 +1859,9 @@ HTML;
                 $inner
               </div>
               <br/>
-              $disclaimer
+              <div id="simplyrets-listings-slider-disclaimer" style="text-align:center;">
+                $disclaimer
+              </div>
             </div>
 HTML;
 

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -197,8 +197,11 @@ HTML;
      *   - settings: a key/value of settings (non-search attributes)
      */
     public static function parseShortcodeAttributes($atts, $setting_atts = array()) {
-        $params = array();
-        $settings = array();
+        $attributes = array("params" => array(), "settings" => array());
+
+        if (!$atts) {
+            return $attributes;
+        }
 
         foreach ($atts as $param=>$value_) {
             // Ensure "&" is not HTML encoded
@@ -207,7 +210,7 @@ HTML;
 
             // Parse settings, don't add them to the API query
             if (in_array($param, $setting_atts)) {
-                $settings[$param] = $value;
+                $attributes["settings"][$param] = $value;
                 break;
             }
 
@@ -216,15 +219,15 @@ HTML;
                 $values[$idx] = trim($val);
             }
 
-            $params[$param] = count($values) > 1 ? $values : $value;
+            $attributes["params"][$param] = count($values) > 1 ? $values : $value;
 
-            // Pass certain settings through as an array
+            // Add vendor to params and settings
             if ($param === "vendor") {
-                $settings["vendor"] = $value;
+                $attributes["settings"]["vendor"] = $value;
             }
         }
 
-        return array("params" => $params, "settings" => $settings);
+        return $attributes;
     }
 
     public static function sr_openhouses_shortcode($atts = array()) {

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -197,7 +197,7 @@ HTML;
      *   - settings: a key/value of settings (non-search attributes)
      */
     public static function parseShortcodeAttributes($atts, $setting_atts = array()) {
-        $attributes = array("params" => array(), "settings" => array());
+        $attributes = array("params" => array(), "settings" => $setting_atts);
 
         if (!$atts) {
             return $attributes;
@@ -209,7 +209,7 @@ HTML;
             $value = str_replace("&amp;", "&", $value_);
 
             // Parse settings, don't add them to the API query
-            if (in_array($param, $setting_atts)) {
+            if (array_key_exists($param, $setting_atts)) {
                 $attributes["settings"][$param] = $value;
                 break;
             }
@@ -248,7 +248,7 @@ HTML;
      * ie, [sr_residential mlsid="12345"]
      */
     public static function sr_residential_shortcode($atts = array ()) {
-        $setting_atts = array("map_position", "show_map");
+        $setting_atts = array("map_position" => "map_above", "show_map" => "true");
         $data = SrShortcodes::parseShortcodeAttributes($atts, $setting_atts);
 
         // Use /properties/:id if `mlsid` parameter is used
@@ -658,20 +658,18 @@ HTML;
      * TODO: sr_listings_slider should support attributes that can
      * take multiple values (eg, postalCodes, counties). #32
      */
-    public static function sr_listing_slider_shortcode( $atts ) {
+    public static function sr_listing_slider_shortcode($atts = array()) {
         ob_start();
-        $settings = array();
 
-        $atts['limit'] = empty($atts['limit']) ? 8 : $atts['limit'];
+        $def_params = array("limit" => "12");
+        $def_settings = array("random" => "false");
+        $def_atts = array_merge($def_params, is_array($atts) ? $atts : array());
 
-        if ($atts['vendor']) {
-            $settings['vendor'] = $atts['vendor'];
-        }
+        $data = SrShortcodes::parseShortcodeAttributes($def_atts, $def_settings);
 
-        $settings['random'] = empty($atts['random']) ? NULL : $atts['random'];
-        $slider = SimplyRetsApiHelper::retrieveListingsSlider($atts, $settings);
-
-        echo $slider;
+        echo SimplyRetsApiHelper::retrieveListingsSlider(
+            $data["params"], $data["settings"]
+        );
 
         return ob_get_clean();
     }

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -471,6 +471,30 @@ class SrListing {
         $useStatusText = get_option('sr_show_mls_status_text', false);
         return $useStatusText ? $listing->mls->statusText : $listing->mls->status;
     }
+
+    /**
+     * Return a 'display-ready' number of bathrooms for a
+     * listing. Checks for `.property.bathrooms` first, and then
+     * `.property.bathsFull`, and pluralizes the "bath(s)" text.
+     */
+    public static function getBathroomsDisplay(
+        $bathrooms,
+        $bathsFull = 0,
+        $small_text = false
+    ) {
+        if (is_numeric($bathrooms)) {
+            $s = $bathrooms > 1 ? "s" : "";
+            $e = $small_text ? "<small>Bath$s</small>" : "Bath$s";
+
+            return "$bathrooms $e";
+        }
+
+        $s = $bathsFull > 1 ? "s" : "";
+        $b = $bathsFull > 0 ? $bathsFull : "n/a";
+        $e = $small_text ? "<small>Full bath$s</small>" : "Full bath$s";
+
+        return "$b Full bath$s";
+    }
 }
 
 

--- a/src/simply-rets-widgets.php
+++ b/src/simply-rets-widgets.php
@@ -117,7 +117,7 @@ class srFeaturedListingWidget extends WP_Widget {
         $mlsid = $instance['mlsid'];
         $vendor = $instance['vendor'];
 
-        $cont .= $before_widget;
+        $cont = $before_widget;
         // populate title
         if( $title ) {
             $cont .= $before_title . $title . $after_title;
@@ -228,7 +228,7 @@ class srAgentListingWidget extends WP_Widget {
        $limit  = $instance['limit'];
        $vendor = $instance['vendor'];
 
-       $cont .= $before_widget;
+       $cont = $before_widget;
        // populate title
        if( $title ) {
            $cont .= $before_title . $title . $after_title;
@@ -334,7 +334,7 @@ class srRandomListingWidget extends WP_Widget {
 
         $mlsid = trim($mlsids_arr[array_rand($mlsids_arr)]);
 
-        $cont .= $before_widget;
+        $cont = $before_widget;
 
         // populate title
         if( $title ) {
@@ -415,7 +415,7 @@ class srSearchFormWidget extends WP_Widget {
         $title  = apply_filters('widget_title', $instance['title']);
         $vendor = apply_filters('widget_vendor', $instance['vendor']);
 
-        $cont .= $before_widget;
+        $cont = $before_widget;
 
         // populate title
         if( $title ) {


### PR DESCRIPTION
This updates all of the places where we show a "preview" of the total bathrooms for a listing to use consistent logic as described in #160 (fixes #160).

- [x] Listing details page primary details
- [x] All widgets that show a listing
- [x] `[sr_listings_slider]` output
- [x] `[sr_residential]` output