### PR TITLE
Fix parsing camelCase API parameters from short-code attributes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.9
+* FIX: Fix parsing multiple `brokers` parameters in [sr_search_form].
+* EHANCEMENT: Support `exteriorFeatures` parameter on all short-codes.
+
 ## 2.8.8
 * FIX: Use consistent logic when displaying total or full baths in listing previews.
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 5.4
-Stable tag: 2.8.8
+Stable tag: 2.8.9
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.8.9 =
+* FIX: Fix parsing multiple `brokers` parameters in `[sr_search_form]`.
+* EHANCEMENT: Support `exteriorFeatures` parameter on all short-codes.
 
 = 2.8.8 =
 * FIX: Use consistent logic when displaying total or full baths in listing previews.

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -119,7 +119,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.8.8 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.8.9 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -240,7 +240,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.8.8 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.8.9 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -721,8 +721,8 @@ class SimplyRetsCustomPostPages {
                 $_GET
             );
 
-            $postalCodes = $postalCodesData["param"];
-            $postalCodes_string = $postalCodesData["query"];
+            $postalCodes_att = $postalCodesData["att"];
+            $postalCodes_query = $postalCodesData["query"];
 
             /** Parse multiple subtypes from short-code parameter */
             $subtypeData = SimplyRetsCustomPostPages::parseGetParameter(
@@ -731,9 +731,8 @@ class SimplyRetsCustomPostPages {
                 $_GET
             );
 
-            $subtype = $subtypeData["param"];
             $subtype_att = $subtypeData["att"];
-            $subtype_string = $subtypeData["query"];
+            $subtype_query = $subtypeData["query"];
 
             /** Parse multiple cities from short-code parameter */
             $citiesData = SimplyRetsCustomPostPages::parseGetParameter(
@@ -742,8 +741,8 @@ class SimplyRetsCustomPostPages {
                 $_GET
             );
 
-            $cities = $citiesData["param"];
-            $cities_string = $citiesData["query"];
+            $cities_att = $citiesData["att"];
+            $cities_query = $citiesData["query"];
 
             /** Parse multiple counties from short-code parameter */
             $countiesData = SimplyRetsCustomPostPages::parseGetParameter(
@@ -752,8 +751,8 @@ class SimplyRetsCustomPostPages {
                 $_GET
             );
 
-            $counties = $countiesData["param"];
-            $counties_string = $countiesData["query"];
+            $counties_att = $countiesData["att"];
+            $counties_query = $countiesData["query"];
 
             /** Parse multiple neighborhoods from short-code parameter */
             $neighborhoodsData = SimplyRetsCustomPostPages::parseGetParameter(
@@ -762,8 +761,18 @@ class SimplyRetsCustomPostPages {
                 $_GET
             );
 
-            $neighborhoods = $neighborhoodsData["param"];
-            $neighborhoods_string = $neighborhoodsData["query"];
+            $neighborhoods_att = $neighborhoodsData["att"];
+            $neighborhoods_query = $neighborhoodsData["query"];
+
+            /** Parse multiple exteriorFeatures from short-code parameter */
+            $exteriorFeaturesData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_exteriorFeatures",
+                "exteriorFeatures",
+                $_GET
+            );
+
+            $exteriorFeatures_att = $exteriorFeaturesData["att"];
+            $exteriorFeatures_query = $exteriorFeaturesData["query"];
 
             /**
              * If `sr_q` is set, the user clicked a pagination link
@@ -861,10 +870,11 @@ class SimplyRetsCustomPostPages {
                 "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false",
                 "subtype" => $subtype_att,
-                "postalCodes" => $postalCodes,
-                "cities" => $cities,
-                "counties" => $counties,
-                "neighborhoods" => $neighborhoods
+                "postalCodes" => $postalCodes_att,
+                "cities" => $cities_att,
+                "counties" => $counties_att,
+                "neighborhoods" => $neighborhoods_att,
+                "exteriorFeatures" => $exteriorFeatures_att
             );
 
             // Create a string of attributes to put on the
@@ -876,20 +886,20 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
-
             // Final API query string
             $qs = '?'
                 . http_build_query( array_filter( $listing_params ) )
                 . $features_string
-                . $cities_string
-                . $counties_string
-                . $neighborhoods_string
-                . $postalCodes_string
+                . $cities_query
+                . $counties_query
+                . $neighborhoods_query
+                . $postalCodes_query
                 . $agents_string
                 . $ptypes_string
-                . $subtype_string
+                . $subtype_query
                 . $statuses_string
                 . $amenities_string
+                . $exteriorFeatures_query
                 . $q_string;
 
             $qs = str_replace(' ', '%20', $qs);

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -597,7 +597,6 @@ class SimplyRetsCustomPostPages {
             $maxbaths = get_query_var( 'sr_maxbaths', '' );
             $minprice = get_query_var( 'sr_minprice', '' );
             $maxprice = get_query_var( 'sr_maxprice', '' );
-            $brokers  = get_query_var( 'sr_brokers', '' );
             $water    = get_query_var( 'water', '' );
             /** Pagination */
             $limit    = get_query_var( 'limit', '' );
@@ -698,14 +697,6 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
-            $agents = isset($_GET['sr_agent']) ? $_GET['sr_agent'] : '';
-            $agents_string = "";
-            if(!empty($agents)) {
-                foreach((array)$agents as $key => $agent) {
-                    $agents_string .= "&agent=$agent";
-                }
-            }
-
             $amenities = isset($_GET['sr_amenities']) ? $_GET['sr_amenities'] : '';
             $amenities_string = "";
             if(!empty($amenities)) {
@@ -713,6 +704,26 @@ class SimplyRetsCustomPostPages {
                     $amenities_string .= "&amenities=$amenity";
                 }
             }
+
+            /** Parse multiple brokers from short-code parameter */
+            $brokersData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_brokers",
+                "brokers",
+                $_GET
+            );
+
+            $brokers_att = $brokersData["att"];
+            $brokers_query = $brokersData["query"];
+
+            /** Parse multiple agent from short-code parameter */
+            $agentData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_agent",
+                "agent",
+                $_GET
+            );
+
+            $agent_att = $agentData["att"];
+            $agent_query = $agentData["query"];
 
             /** Parse multiple postalCodes from short-code parameter */
             $postalCodesData = SimplyRetsCustomPostPages::parseGetParameter(
@@ -815,7 +826,6 @@ class SimplyRetsCustomPostPages {
              */
 
             $listing_params = array(
-                "brokers"   => $brokers,
                 "minbeds"   => $minbeds,
                 "maxbeds"   => $maxbeds,
                 "minbaths"  => $minbaths,
@@ -866,10 +876,11 @@ class SimplyRetsCustomPostPages {
 
             $next_atts = $listing_params + array(
                 "q" => $kw_string,
-                "agent" => get_query_var('sr_agent', ''),
                 "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false",
                 "subtype" => $subtype_att,
+                "agent" => $agent_att,
+                "brokers" => $brokers_att,
                 "postalCodes" => $postalCodes_att,
                 "cities" => $cities_att,
                 "counties" => $counties_att,
@@ -889,12 +900,13 @@ class SimplyRetsCustomPostPages {
             // Final API query string
             $qs = '?'
                 . http_build_query( array_filter( $listing_params ) )
+                . $agent_query
+                . $brokers_query
                 . $features_string
                 . $cities_query
                 . $counties_query
                 . $neighborhoods_query
                 . $postalCodes_query
-                . $agents_string
                 . $ptypes_string
                 . $subtype_query
                 . $statuses_string

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -229,7 +229,7 @@ HTML;
             // Parse settings, don't add them to the API query
             if (array_key_exists($param, $setting_atts)) {
                 $attributes["settings"][$param] = $value;
-                break;
+                continue;
             }
 
             $values = explode(";", $value);

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -192,6 +192,23 @@ HTML;
     }
 
     /**
+     * WordPress downcases all attribute names. This function will
+     * take a downcased parameter and convert it to the SimplyRETS
+     * parameter name.
+     */
+    public static function attributeNameToParameter($name) {
+        $fixes = array(
+            "exteriorfeatures" => "exteriorFeatures",
+            "postalcodes" => "postalCodes",
+            "mingaragespaces" => "minGarageSpaces",
+            "maxgaragespaces" => "maxGarageSpaces",
+            "salesagent" => "salesAgent"
+        );
+
+        return array_key_exists($name, $fixes) ? $fixes[$name] : $name;
+    }
+
+    /**
      * Take an array of short-code attributes and parse them. Returns:
      *   - params: an array of API search parameters
      *   - settings: a key/value of settings (non-search attributes)
@@ -207,6 +224,7 @@ HTML;
             // Ensure "&" is not HTML encoded
             // https://stackoverflow.com/a/20078112/3464723
             $value = str_replace("&amp;", "&", $value_);
+            $name = SrShortcodes::attributeNameToParameter($param);
 
             // Parse settings, don't add them to the API query
             if (array_key_exists($param, $setting_atts)) {
@@ -219,7 +237,7 @@ HTML;
                 $values[$idx] = trim($val);
             }
 
-            $attributes["params"][$param] = count($values) > 1 ? $values : $value;
+            $attributes["params"][$name] = count($values) > 1 ? $values : $value;
 
             // Add vendor to params and settings
             if ($param === "vendor") {

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.8.8
+Version: 2.8.9
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Wordpress downcases all short-code attribute names, where our API expects a camelCase parameter name.

This adds a function to convert a short-code attribute to an API parameter. For example:

```
"exteriorfeatures" => "exteriorFeatures"
"postalcodes" => "postalCodes"
```

Fixes #163 