### PR TITLE
Fix PHP warnings and notices

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.9.1
+* FIX: Update code to fix various PHP warnings and notices.
+
 ## 2.9.0
 * FIX: Update `ivory-google-map` vendor library to fix issue loading Google Maps.
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 5.4
-Stable tag: 2.9.0
+Tested up to: 5.4.2
+Stable tag: 2.9.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.9.1 =
+* FIX: Update code to fix various PHP warnings and notices.
 
 = 2.9.0 =
 * FIX: Update `ivory-google-map` vendor library to fix issue loading Google Maps.

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -568,7 +568,7 @@ HTML;
         // Boolean for fetching open houses
         $has_openhouses = in_array(
             "/openhouses",
-            get_option("sr_adv_search_meta_endpoints", array())
+            (array)get_option("sr_adv_search_meta_endpoints", array())
         );
 
         $last_update = $listing['lastUpdate'];
@@ -579,8 +579,8 @@ HTML;
          * The error code comes from the UrlBuilder function.
         */
         if($listing == NULL
-           || array_key_exists("error", $listing)
-           || array_key_exists("errors", $listing)) {
+           || property_exists($listing, "error")
+           || property_exists($listing, "errors")) {
             $err = SrMessages::noResultsMsg((array)$listing);
             return $err;
         }

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -124,7 +124,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.9.0 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.9.1 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -245,7 +245,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.9.0 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.9.1 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -428,21 +428,7 @@ HTML;
                  ."<label><input name='sr_features[]' type='checkbox' value='$feature' $checked />$feature</label></li>";
         }
 
-
-        // currently unused
-        // $adv_search_counties = get_option( 'sr_adv_search_meta_county' );
-        // foreach( $adv_search_counties as $key=>$county) {
-        //     $county_options .= "<option value='$county' />$county</option>";
-        // }
-
-        // currently unused
-        // $adv_search_amenities = get_option( 'sr_adv_search_option_amenities' );
-        // foreach( $adv_search_amenities as $key=>$amenity) {
-        //     $amenity_options .= "<li class='sr-adv-search-option'>"
-        //         ."<label><input name='sr_features[]' type='checkbox' value='$amenity' />$amenity</label></li>";
-        // }
-
-        if( array_key_exists('advanced', $atts) && $atts['advanced'] == 'true' || $atts['advanced'] == 'True' ) {
+        if(array_key_exists('advanced', $atts) && ($atts['advanced'] == 'true' || $atts['advanced'] == 'True')) {
             ?>
 
             <div class="sr-adv-search-wrap">

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -13,10 +13,12 @@ class SrUtils {
 
 
     public static function isSingleVendor() {
-        $vendors = get_option('sr_adv_search_meta_vendors', array());
+        $vendors = (array)get_option('sr_adv_search_meta_vendors', array());
+
         if(count($vendors) > 1) {
             return false;
         }
+
         return true;
     }
 

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.9.0
+Version: 2.9.1
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
### Fix PHP warnings and notices

- Fixes #173
  **Reproduce**: View any single listing details page

- Fixes Notice: `Undefined index 'advanced' when rendering [sr_search_form]`
  **Reproduce**: When using `[sr_search_form]`

- Fixes Warning: `Count expects an array or object in SrUtils::isSingleVendor`
  **Reproduce**: When using `[sr_map_search]`

---

Test these changes by installing this plugin zip file: 
[simplyretswp-v2.9.1-beta.zip](https://github.com/SimplyRETS/simplyretswp/files/4833446/simplyretswp-v2.9.1-beta.zip)