### PR TITLE
Add subTypeText filter / show subTypeText in listing details

### DIFF
--- a/src/assets/js/simply-rets-client.js
+++ b/src/assets/js/simply-rets-client.js
@@ -309,6 +309,27 @@ var updatePagination = function(that) {
 }
 
 
+function normalizeParameters(params) {
+    var obj = {}
+
+    Object.keys(params).map(function(key) {
+        if (key === "subtypetext")
+            return obj.subTypeText = params[key]
+        if (key === "exteriorfeatures")
+            return obj.exteriorFeatures = params[key]
+        if (key === "mingaragespaces")
+            return obj.minGarageSpaces = params[key]
+        if (key === "maxgaragespaces")
+            return obj.maxGarageSpaces = params[key]
+        if (key === "salesagent")
+            return obj.salesAgent = params[key]
+
+        return obj[key] = params[key]
+    })
+
+    return obj
+}
+
 var getSearchFormValues = function() {
 
     var keyword  = $_('.sr-int-map-search-wrapper #sr-search-keywords > input[type="text"]').val(),
@@ -334,7 +355,7 @@ var getSearchFormValues = function() {
     // Merge the default parameters on the short-code with the
     // user-selected parameters. If the user hasn't selected a value
     // for an input, fallback to the default.
-    var params = Object.assign({}, defParams, {
+    var params = Object.assign({}, normalizeParameters(defParams), {
         q:        keyword || defParams.q,
         type:     ptype || defParams.type,
         sort:     sort,

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -621,12 +621,10 @@ HTML;
         $listing_type = SrUtils::normalizePropertyType($listing->property->type);
         $type = SimplyRetsApiHelper::srDetailsTable($listing_type, "Property Type");
         // subtype
-        $listing_subType_ = $listing->property->subType;
+        $listing_subType = $listing->property->subType;
+        $subType = SimplyRetsApiHelper::srDetailsTable($listing_subType, "Sub type");
         $listing_subTypeText = $listing->property->subTypeText;
-        $listing_subType = !empty($listing_subType_)
-                         ? $listing_subType_
-                         : $listing_subTypeText;
-        $subType = SimplyRetsApiHelper::srDetailsTable($listing_subType, "Sub Type");
+        $subTypeText = SimplyRetsApiHelper::srDetailsTable($listing_subTypeText, "MLS Sub type");
         // bedrooms
         $listing_bedrooms = $listing->property->bedrooms;
         $bedrooms = SimplyRetsApiHelper::srDetailsTable($listing_bedrooms, "Bedrooms");
@@ -1227,6 +1225,7 @@ HTML;
 
                 $type
                 $subType
+                $subTypeText
                 $stories
                 $interiorFeatures
                 $exteriorFeatures

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -181,6 +181,7 @@ class SimplyRetsCustomPostPages {
         $vars[] = "sr_type";
         $vars[] = "sr_ptype";
         $vars[] = "sr_subtype";
+        $vars[] = "sr_subTypeText";
         $vars[] = "sr_agent";
         $vars[] = "sr_brokers";
         $vars[] = "sr_sort";
@@ -745,6 +746,16 @@ class SimplyRetsCustomPostPages {
             $subtype_att = $subtypeData["att"];
             $subtype_query = $subtypeData["query"];
 
+            /** Parse multiple subtypes from short-code parameter */
+            $subTypeTextData = SimplyRetsCustomPostPages::parseGetParameter(
+                "sr_subTypeText",
+                "subTypeText",
+                $_GET
+            );
+
+            $subTypeText_att = $subTypeTextData["att"];
+            $subTypeText_query = $subTypeTextData["query"];
+
             /** Parse multiple cities from short-code parameter */
             $citiesData = SimplyRetsCustomPostPages::parseGetParameter(
                 "sr_cities",
@@ -879,6 +890,7 @@ class SimplyRetsCustomPostPages {
                 "status" => $statuses_attribute,
                 "advanced" => $advanced == "true" ? "true" : "false",
                 "subtype" => $subtype_att,
+                "subTypeText" => $subTypeText_att,
                 "agent" => $agent_att,
                 "brokers" => $brokers_att,
                 "postalCodes" => $postalCodes_att,
@@ -909,6 +921,7 @@ class SimplyRetsCustomPostPages {
                 . $postalCodes_query
                 . $ptypes_string
                 . $subtype_query
+                . $subTypeText_query
                 . $statuses_string
                 . $amenities_string
                 . $exteriorFeatures_query

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -202,7 +202,8 @@ HTML;
             "postalcodes" => "postalCodes",
             "mingaragespaces" => "minGarageSpaces",
             "maxgaragespaces" => "maxGarageSpaces",
-            "salesagent" => "salesAgent"
+            "salesagent" => "salesAgent",
+            "subtypetext" => "subTypeText"
         );
 
         return array_key_exists($name, $fixes) ? $fixes[$name] : $name;
@@ -311,6 +312,7 @@ HTML;
         $limit   = isset($atts['limit'])   ? $atts['limit']   : '';
         $config_type = isset($atts['type']) ? $atts['type']   : '';
         $subtype = isset($atts['subtype']) ? $atts['subtype'] : '';
+        $subTypeText = isset($atts['subtypetext']) ? $atts['subtypetext'] : '';
         $counties = isset($atts['counties']) ? $atts['counties'] : '';
         $postalCodes = isset($atts['postalcodes']) ? $atts['postalcodes'] : '';
         $neighborhoods = isset($atts['neighborhoods']) ? $atts['neighborhoods'] : '';
@@ -553,6 +555,7 @@ HTML;
                 <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
                 <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
                 <input type="hidden" name="sr_subtype" value="<?php echo $subtype; ?>" />
+                <input type="hidden" name="sr_subTypeText" value="<?php echo $subTypeText; ?>" />
                 <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
                 <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
                 <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
@@ -643,6 +646,7 @@ HTML;
             <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
             <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
             <input type="hidden" name="sr_subtype" value="<?php echo $subtype; ?>" />
+            <input type="hidden" name="sr_subTypeText" value="<?php echo $subTypeText; ?>" />
             <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
             <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
             <input type="hidden" name="sr_neighborhoods" value="<?php echo $neighborhoods; ?>" />


### PR DESCRIPTION
- [x] Add support for `subTypeText` filter
- [x] Show `subTypeText` on listing details pages

Try it out: [simplyretswp-v2.9.2.zip](https://github.com/SimplyRETS/simplyretswp/files/5405330/simplyretswp-v2.9.2.zip)
