### PR TITLE
Add option for force loading images over HTTPS

### DIFF
--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -58,6 +58,9 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_date_default_timezone', array(
           "default" => ""
       ));
+      register_setting('sr_admin_settings', 'sr_listing_force_image_https', array(
+          "default" => false
+      ));
   }
 
   public static $timezones = array(
@@ -331,6 +334,32 @@ class SrAdminSettings {
                       ?>
                       Classic Gallery
                     </label>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <br/>
+            <table>
+              <tbody>
+                <tr>
+                  <td colspan="2">
+                    <label>
+                      <?php echo
+                        '<input type="checkbox" id="sr_listing_force_image_https" name="sr_listing_force_image_https" value="1" '
+                        . checked(1, get_option('sr_listing_force_image_https'), false) . '/>'
+                      ?>
+                        Force images to load using <code>https://</code>
+                    </label>
+                    <br/>
+                    <p style="padding-left:25px;max-width:350px;margin-bottom:0px">
+                        <small>
+                            Enabling this loads all images using
+                            <code>https://</code> to prevent a Mixed
+                            Content warning in the browser on sites
+                            using SSL. (Note that not all data
+                            providers support HTTPS image URLs.)
+                        </small>
+                    </p>
                   </td>
                 </tr>
               </tbody>

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -483,6 +483,15 @@ HTML;
 
 
 
+    public static function normalizeListingPhotoUrl($url) {
+        $force_https = get_option("sr_listing_force_image_https", false);
+
+        if ($force_https) {
+            return str_replace("http://", "https://", $url);
+        } else {
+            return $url;
+        }
+    }
     /**
      * Build the photo gallery shown on single listing details pages
      */
@@ -505,10 +514,11 @@ HTML;
                 $more = '<span id="sr-toggle-gallery">See more photos</span> |';
                 $markup .= "<div class='sr-slider'><img class='sr-slider-img-act' src='$main_photo'>";
                 foreach( $photos as $photo ) {
+                    $image_url = SimplyRetsApiHelper::normalizeListingPhotoUrl($photo);
                     $markup .=
                         "<input class='sr-slider-input' type='radio' name='slide_switch' id='id$photo_counter' value='$photo' />";
                     $markup .= "<label for='id$photo_counter'>";
-                    $markup .= "  <img src='$photo' width='100'>";
+                    $markup .= "  <img src='$image_url' width='100'>";
                     $markup .= "</label>";
                     $photo_counter++;
                 }
@@ -536,6 +546,7 @@ HTML;
 
                 foreach( $photos as $idx=>$photo ) {
                     $num = $idx + 1;
+                    $image_url = SimplyRetsApiHelper::normalizeListingPhotoUrl($photo);
                     $img_description = "<div>"
                                      . "  <div>Photo {$num} of {$photos_count}</div>"
                                      . "  <div style=\"{$description_style}\">"
@@ -543,7 +554,7 @@ HTML;
                                      . "  </div>"
                                      . "</div>";
 
-                    $markup .= "<img src='$photo' "
+                    $markup .= "<img src='$image_url' "
                             . "data-title='$full_address'"
                             . "data-description='$img_description'>";
                 }
@@ -1456,6 +1467,7 @@ HTML;
             }
             $main_photo = trim($listingPhotos[0]);
             $main_photo = str_replace("\\", "", $main_photo);
+            $main_photo = SimplyRetsApiHelper::normalizeListingPhotoUrl($main_photo);
 
             // listing link to details
             $link = SrUtils::buildDetailsLink(


### PR DESCRIPTION
This setting affects both the search results and the single listing page, and ensures all images are loaded over `https` even when `http` is provided from the data source.