### PR TITLE
Support force_image_https setting on all short-codes

### DIFF
--- a/src/assets/js/simply-rets-client.js
+++ b/src/assets/js/simply-rets-client.js
@@ -102,6 +102,19 @@ var buildUglyLink = function(mlsId, address, root, vendor) {
          + (vendor ? ("&sr_vendor=" + vendor) : "");
 }
 
+var normalizeListingPhotoUrl = function(url) {
+    var forceHttps = document
+        .getElementById("sr-map-search")
+        .dataset
+        .forceImageHttps
+
+    if (forceHttps) {
+        return url.replace(/^http:\/\//i, 'https://')
+    } else {
+        return url
+    }
+}
+
 
 var genMarkerPopup = function(
     listing,
@@ -126,7 +139,7 @@ var genMarkerPopup = function(
     var price = listing.listPrice          || "Unknown";
     var addr  = listing.address.full       || "Unknown";
     var photo = listing.photos.length > 1
-              ? listing.photos[0]
+              ? normalizeListingPhotoUrl(listing.photos[0])
               : 'https://s3-us-west-2.amazonaws.com/simplyrets/trial/properties/defprop.jpg';
     var office = officeOnThumbnails && listing.office.name
                ? listing.office.name

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -894,7 +894,9 @@ HTML;
         $gallery_markup = $photo_gallery['markup'];
         $more_photos    = $photo_gallery['more'];
         $dummy          = plugins_url( 'assets/img/defprop.jpg', __FILE__ );
-        $main_photo     = !empty($photos) ? $photos[0] : $dummy;
+
+        $main_photo = !empty($photos) ? $photos[0] : $dummy;
+        $main_photo = SimplyRetsApiHelper::normalizeListingPhotoUrl($main_photo);
 
         // geographic data
         if($geo_directions
@@ -1694,6 +1696,7 @@ HTML;
             }
             $main_photo = $listingPhotos[0];
             $main_photo = str_replace("\\", "", $main_photo);
+            $main_photo = SimplyRetsApiHelper::normalizeListingPhotoUrl($main_photo);
 
             // Compliance markup (agent/office)
             $listing_office  = $listing->office->name;

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1856,6 +1856,7 @@ HTML;
             } else {
                 $photo = trim($photos[0]);
                 $photo = str_replace("\\", "", $photo);
+                $photo = SimplyRetsApiHelper::normalizeListingPhotoUrl($photo);
             }
 
             $bathsFull  = $l->property->bathsFull;

--- a/src/simply-rets-openhouses.php
+++ b/src/simply-rets-openhouses.php
@@ -117,6 +117,7 @@ HTML;
         // Photo markup and styles
         $dummy = plugins_url( 'assets/img/defprop.jpg', __FILE__ );
         $main_photo = !empty($listing->photos) ? $listing->photos[0] : $dummy;
+        $photo_url = SimplyRetsApiHelper::normalizeListingPhotoUrl($main_photo);
         $photo_style = "background-image:url('$main_photo');background-size:cover;";
 
         // Agent/office compliance markup

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -60,6 +60,7 @@ class SrShortcodes {
         $idx_img     = get_option('sr_thumbnail_idx_image');
         $office_on_thumbnails = get_option('sr_office_on_thumbnails', false);
         $agent_on_thumbnails = get_option('sr_agent_on_thumbnails', false);
+        $force_image_https = get_option('sr_listing_force_image_https', false);
 
         // Delete attributes that aren't API parameters
         $default_parameters = array_diff_key($atts, [
@@ -75,6 +76,7 @@ class SrShortcodes {
                              data-idx-img='{$idx_img}'
                              data-office-on-thumbnails='{$office_on_thumbnails}'
                              data-agent-on-thumbnails='{$agent_on_thumbnails}'
+                             data-force-image-https='{$force_image_https}'
                              data-limit='{$limit}'
                              data-default-parameters='{$default_parameters_json}'
                              data-vendor='{$vendor}'></div>";


### PR DESCRIPTION
This features was added to listing search results and details pages in in v2.9.4. This PR adds support  for this short-code in the remaining areas:

- [x] `[sr_map_search]` / map marker info windows
- [x] `[sr_listings_slider]`
- [x] `[sr_openhouses]`
- [x] Featured/Random/Agents listing widgets