### PR TITLE
Use better HTML for images in sr_listings/sr_listings_slider

### DIFF
--- a/src/assets/css/simply-rets-client.css
+++ b/src/assets/css/simply-rets-client.css
@@ -59,15 +59,11 @@ of the image, use this class.
 ```
 
 */
-.sr-photo {
-    position: relative;
+img.sr-photo {
     display: inline-block;
     height: 155px;
     width: 30%;
     overflow: hidden;
-    background-size: contain;
-    background-position: center center;
-    background-repeat: no-repeat;
 }
 
 
@@ -918,11 +914,9 @@ elsewhere, this should be a breeze.
     text-align: center;
 }
 
-.sr-listing-slider-item-img {
-    height: 170px;
-    background-size: contain;
-    background-position: center;
-    background-repeat: no-repeat;
+img.sr-listing-slider-item-img {
+    height: 150px;
+    object-fit: cover;
 }
 
 .sr-listing-slider-item-address {

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1538,8 +1538,12 @@ HTML;
               <hr>
               <div class="sr-listing">
                 <a href="$link">
-                  <div class="sr-photo" style="background-image:url('$main_photo');">
-                  </div>
+                  <img
+                    src="$main_photo"
+                    alt="$full_address - $listing_USD"
+                    title="$full_address - $listing_USD"
+                    class="sr-photo"
+                  />
                 </a>
                 <div class="sr-listing-data-wrapper">
                   <div class="sr-primary-data">
@@ -1849,7 +1853,12 @@ HTML;
             $inner .= <<<HTML
                 <div class="sr-listing-slider-item">
                   <a href="$link">
-                    <div class="sr-listing-slider-item-img" style="background-image: url('$photo')"></div>
+                    <img
+                      src="$photo"
+                      alt="$address - $priceUSD"
+                      title="$address - $priceUSD"
+                      class="sr-listing-slider-item-img"
+                   />
                   </a>
                   <a href="$link">
                     <h4 class="sr-listing-slider-item-address">$address <small>$priceUSD</small></h4>


### PR DESCRIPTION
Use an `<img/>` tag for the photo in `[sr_listings]` and `[sr_listings_slider]` instead of a `<div>`.

Also add an `alt` and `title` attribute to these images, to improve SEO.