### PR TITLE
Correctly initialize multiple listings sliders on one page

### DIFF
--- a/src/assets/js/simply-rets-client.js
+++ b/src/assets/js/simply-rets-client.js
@@ -73,8 +73,8 @@ var advSearchFormToggler = function() {
 /** [sr_listings_slider] default number of items */
 var listingSliderCarousel = function() {
 
-    $_("#simplyrets-listings-slider").owlCarousel({
-        items: 4
+    $_(".sr-listing-carousel").each(function() {
+        $_(this).owlCarousel({ items: 4 })
     });
 
 }


### PR DESCRIPTION
This updates the client JS to allow using multiple `[sr_listings_slider]` short-codes on the same page.