### PR TITLE
Fix fatal error on listing detail

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -847,7 +847,7 @@ HTML;
         // Rooms data
         $roomsMarkup = '';
         $has_rooms = !empty($listing->property->rooms)
-                   AND is_array($listing->property-rooms);
+                   AND is_array($listing->property->rooms);
 
         if($has_rooms == TRUE) {
             $rooms = $listing->property->rooms;


### PR DESCRIPTION
The single listing was throwing a fatal error due to a missing character. All is good now.