### PR TITLE
Display compliance/compensation data on listing details pages

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -783,24 +783,20 @@ HTML;
 
         // Compliance/compensation data
         $complianceData = $listing->compliance;
-        $compensation = "";
+        $complianceExtras = "";
         foreach ($complianceData as $compKey => $compValue) {
             // Normalize camelCase keys to words
             $compKey = ucfirst(preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', $compKey));
+            $complianceExtras .= SimplyRetsApiHelper::srDetailsTable($compValue, $compKey);
+        }
 
-            // Add $/% signs where necessary
-            if(!strpos($compValue, "%") AND !strpos($compValue, "$")) {
-                if ($compValue == 0) {
-                    $compValue = "0";
-                } else if ($compValue < 10) {
-                    $compValue = $compValue . "%";
-                } else {
-                    $compValue = "$" . $compValue;
-                }
-            }
-
-            // Append table row for this key/value
-            $compensation .= SimplyRetsApiHelper::srDetailsTable($compValue, $compKey);
+        $compensationDisclaimer = "";
+        if (!empty($complianceExtras)) {
+            $compensationDisclaimer .= SimplyRetsApiHelper::srDetailsTable(
+                "The offer of compensation is made only to participants of " .
+                "the MLS where the listing is filed.",
+                "Compensation Disclaimer"
+            );
         }
 
         $listing_lease_term = $listing->leaseTerm;
@@ -1318,7 +1314,8 @@ HTML;
                 $officeEmail
                 $agent
                 $agent_phone
-                $compensation
+                $complianceExtras
+                $compensationDisclaimer
                 $special_listing_conditions
                 $ownership
                 $terms

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -781,6 +781,28 @@ HTML;
             $listing_ownership, "Ownership"
         );
 
+        // Compliance/compensation data
+        $complianceData = $listing->compliance;
+        $compensation = "";
+        foreach ($complianceData as $compKey => $compValue) {
+            // Normalize camelCase keys to words
+            $compKey = ucfirst(preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', $compKey));
+
+            // Add $/% signs where necessary
+            if(!strpos($compValue, "%") AND !strpos($compValue, "$")) {
+                if ($compValue == 0) {
+                    $compValue = "0";
+                } else if ($compValue < 10) {
+                    $compValue = $compValue . "%";
+                } else {
+                    $compValue = "$" . $compValue;
+                }
+            }
+
+            // Append table row for this key/value
+            $compensation .= SimplyRetsApiHelper::srDetailsTable($compValue, $compKey);
+        }
+
         $listing_lease_term = $listing->leaseTerm;
         $lease_term = SimplyRetsApiHelper::srDetailsTable($listing_lease_term, "Lease Term");
 
@@ -1296,6 +1318,7 @@ HTML;
                 $officeEmail
                 $agent
                 $agent_phone
+                $compensation
                 $special_listing_conditions
                 $ownership
                 $terms

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -562,7 +562,7 @@ class SimplyRetsCustomPostPages {
                 )
             );
 
-            $resource = "/{$listing_id}?{$params}";
+            $resource = "/{$listing_id}?{$params}&include=compliance";
             $content .= SimplyRetsApiHelper::retrieveListingDetails( $resource );
             return $content;
         }


### PR DESCRIPTION
This shows how to access the `.compliance` data in the API response,
and display that information on listing details pages.

The camelCase keys within `.compliance` are normalized and, if there
is a value, are displayed as a table row with the other details.