### PR TITLE
Don't show `next` link when limit > number of results

### DIFF
--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -911,6 +911,7 @@ class SimplyRetsCustomPostPages {
             );
 
             $settings = array(
+                "limit"     => $limit,
                 "map_position" => $map_position
             );
 


### PR DESCRIPTION
Ref #213 #210 

We're working on a fix for an API bug where a `next` link is still returned on the last page when `count=false`.

This addresses that issue by not showing the next link when `limit > page_count`. When the API side is fixed this won't be necessary, but for now it helps decrease error for end users.