### PR TITLE
Allow setting multiple emails in lead capture setting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.9.10
+* FEATURE: Allow multiple emails in lead capture admin setting.
+
 ## 2.9.9
 * FIX: Improve display of pagination links on search result pages.
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 6.1
-Stable tag: 2.9.9
+Stable tag: 2.9.10
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -235,6 +235,9 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.9.10 =
+* FEATURE: Allow multiple emails in lead capture admin setting.
 
 = 2.9.9 =
 * FIX: Improve display of pagination links on search result pages.

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -227,7 +227,12 @@ class SrAdminSettings {
                 <tr>
                   <td>
                     <p><strong>Send Lead Capture forms submissions to:<p></strong>
-                    <input type="email" name="sr_leadcapture_recipient" value="<?php echo esc_attr( get_option('sr_leadcapture_recipient') ); ?>" />
+                    <input
+                        type="email"
+                        name="sr_leadcapture_recipient"
+                        multiple
+                        value="<?php echo esc_attr( get_option('sr_leadcapture_recipient') ); ?>"
+                    />
                   </td>
                 </tr>
               </tbody>

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -124,7 +124,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.9.9 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.9.10 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -245,7 +245,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.9.9 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.9.10 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.9.9
+Version: 2.9.10
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
This updates the `sr_leadcapture_recipient` setting to allow the user to enter multiple email address.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/multiple
