### PR TITLE
Add option for 'sr_lastupdate_offset' and also use it

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.9.11
+* FEATURE: Display compliance fields when available
+* FIX: Some values get cleared when saving admin settings
+
 ## 2.9.10
 * FEATURE: Allow multiple emails in lead capture admin setting.
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: idx, rets, reso web api, mls, idx plugin, mls listings, reso, real estate, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 6.1
-Stable tag: 2.9.10
+Stable tag: 2.9.11
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -237,6 +237,10 @@ listing sidebar widget.
 
 == Changelog ==
 
+= 2.9.11 =
+* FEATURE: Display compliance fields when available
+* FIX: Some values get cleared when saving admin settings
+
 = 2.9.10 =
 * FEATURE: Allow multiple emails in lead capture admin setting.
 
@@ -309,33 +313,6 @@ listing sidebar widget.
 
 = 2.8.0 =
 * ENHANCEMENT: Add support for `idx` admin option and short-code parameter.
-
-= 2.7.2 =
-* ENHANCEMENT: Support all valid API parameters on [sr_map_search] short-code.
-
-= 2.7.1 =
-* FIX: Properly escape remarks for HTML used in fance image gallery.
-
-= 2.7.0 =
-* ENHANCEMENT: Show full address with city, state, and zip for listings in search results.
-* ENHANCEMENT: Add more meta information to the images in the fancy gallery.
-
-= 2.6.4 =
-* FIX: Fix issue where the text "County" is duplicated on search result pages.
-
-= 2.6.3 =
-* ENHANCEMENT: Show listing close price on property details page
-
-= 2.6.2 =
-* ENHANCEMENT: Display property type and subtype on listing details page
-* ENHANCEMENT: Add support for subtype parameter on [sr_listings] and [sr_search_form]
-
-= 2.6.1 =
-* FIX: Fix class and ID attributes on advanced search form markup.
-
-= 2.6.0 =
-* ENHANCEMENT: Allow `neighborhoods`, `cities`, and `counties` parameters on [sr_search_form].
-* ENHANCEMENT: Support ActiveUnderContract listings in SimplyRETS widgets.
 
 [**View the complete CHANGELOG here**](https://github.com/SimplyRETS/simplyretswp/blog/master/CHANGELOG)
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -1,7 +1,7 @@
 === SimplyRETS ===
 Author: SimplyRETS
 Contributors: SimplyRETS
-Tags: rets, idx, idx plugin, mls, mls listings, real estate, simply rets, realtor, rets feed, idx feed
+Tags: idx, rets, reso web api, mls, idx plugin, mls listings, reso, real estate, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 6.1
 Stable tag: 2.9.10
@@ -9,8 +9,9 @@ License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
 Show your Real Estate listings on your website, simply! SimplyRETS
-makes it easy to search and display listings from your MLS on your
-website, and gives you full control over your data.
+makes it easy to search and display MLS listings on your WordPress
+website, and gives you full control over your data. Connect your
+**RETS** or **RESO Web API** feed to get started today.
 
 == Description ==
 
@@ -21,15 +22,15 @@ directly on your Wordpress site. And it can all be set up in less than 5
 minutes!
 
 The SimplyRETS Plugin has the most filtering options of any IDX Plugin
-on the market, with over 25 different ways to create unique pages of
+on the market, with many different ways to create unique pages of
 listings on your site. No iframes, great SEO, and a modern and
-customizable interface for a modern Real Estate site.
+customizable interface for a modern Real Estate website.
 
 To get *your* listings showing through the plugin there's only three steps:
 
 1. [Create an account with SimplyRETS](https://simplyrets.com/account)
-2. Use the RETS credentials from your MLS to [create an app](https://simplyrets.com/blog/getting-set-up.html).
-3. Start getting LIVE listings right on your site!
+2. Use RETS or RESO Web API credentials from your MLS to [create an app](https://simplyrets.com/blog/getting-set-up.html).
+3. Start showing live MLS listing data on your site!
 
 **[View plugin examples and documentation](http://wordpress-demo.simplyrets.com/documentation)**
 
@@ -99,13 +100,13 @@ visitors on your site to look at more properties. If you offer the
 fastest searching solution in your city, why would they go any where
 else?
 
-SimplyRETS uses the RETS (Real Estate Standards Organization)
-protocol. This allows you to be on the leading technical edge and
-provides you with many advantages of IDX (internet data exchange)
-including response speed, compatibility across multiple MLS areas, and
-up-time.  So while your competition is working on getting properties
-on their site, you can install the SimplyRETS Wordpress plugin and
-spend more time actually selling!
+SimplyRETS supports both RETS and RESO Web API feeds.  This allows you
+to be on the leading technical edge and provides you with many
+advantages of IDX (Internet Data Exchange) including response speed,
+compatibility across multiple MLS areas, and up-time.  So while your
+competition is working on getting properties on their site, you can
+install the SimplyRETS Wordpress plugin and spend more time actually
+selling!
 
 
 
@@ -194,7 +195,7 @@ will refresh on average every 2 hours.
 = Do I have to be signed up with an MLS provider? =
 
 Yes. In order for the plugin to show your listings, you first need to
-get a RETS feed set up with your MLS provider.
+set up a RETS or RESO Web API feed with your MLS provider.
 
 = I want to only show my listings, and not my whole office. Is that possible? =
 

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -773,7 +773,7 @@ class SrAdminSettings {
               />
               <ul>
                   <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
-                  <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">relative</a>.</li>
+                  <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
               </ul>
               <?php submit_button(); ?>
           </form>

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -44,6 +44,7 @@ class SrAdminSettings {
       register_setting('sr_admin_settings', 'sr_agent_on_thumbnails');
       register_setting('sr_admin_settings', 'sr_thumbnail_idx_image');
       register_setting('sr_admin_settings', 'sr_custom_disclaimer');
+      register_setting('sr_admin_settings', 'sr_lastupdate_offset');
       register_setting('sr_admin_settings', 'sr_custom_no_results_message');
       register_setting('sr_admin_settings', 'sr_show_mls_status_text');
       register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
@@ -129,6 +130,12 @@ class SrAdminSettings {
       if (isset( $_POST['sr_custom_disclaimer'] )) {
           update_option('sr_custom_disclaimer', htmlentities(stripslashes($_POST['sr_custom_disclaimer'])));
       }
+
+      // Custom POST handler for updating the lastUpdate offset
+      // so we can properly sanitize the input.
+      if (isset( $_POST['sr_lastupdate_offset'] )) {
+        update_option('sr_lastupdate_offset', htmlentities(stripslashes($_POST['sr_lastupdate_offset'])));
+    }
 
       // Custom POST handler for updating the custom disclaimer
       // so we can properly sanitize the input.
@@ -732,44 +739,64 @@ class SrAdminSettings {
             </table>
           </div>
           <?php submit_button(); ?>
-          <div>
-            <h3>Custom disclaimer</h3>
-            <p>Custom disclaimer to be shown with all short-codes</p>
-            <textarea
-                id="sr_custom_disclaimer"
-                name="sr_custom_disclaimer"
-                cols="50"
-                rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
-            <ul>
-                <li>
-                    - Use the variable "{lastUpdate}" to interpolate
-                    the time of the last feed update.
-                </li>
-                <li>
-                    - You can use HTML or plain text.
-                </li>
-            </ul>
-          </div>
-          <?php submit_button(); ?>
-          <div>
-            <h3>No search results message</h3>
-            <p>The messasge shown when a search doesn't return results.</p>
-            <textarea
-                id="sr_custom_no_results_message"
-                name="sr_custom_no_results_message"
-                cols="50"
-                rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
-            <div>
-                <i>
-                    Default: There are 0 listings that match this
-                    search. Try broadening your search criteria or
-                    try again later.
-                </i>
-            </div>
-            <?php submit_button(); ?>
-          </div>
         </form>
-      </div>
-    <?php
+        <hr>
+        <div>
+          <h3>Custom disclaimer</h3>
+          <p>Custom disclaimer to be shown with all short-codes</p>
+          <form method="post" action="options-general.php?page=simplyrets-admin.php">
+              <textarea
+                  id="sr_custom_disclaimer"
+                  name="sr_custom_disclaimer"
+                  cols="50"
+                  rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
+              <ul>
+                  <li>
+                      - Use the variable "{lastUpdate}" to interpolate
+                      the time of the last feed update.
+                  </li>
+                  <li>
+                      - You can use HTML or plain text.
+                  </li>
+              </ul>
+              <?php submit_button(); ?>
+          </form>
+        </div>
+        <div>
+          <h3>lastUpdate Manual Offset</h3>
+          <p>Useful when data coming through the API isn't correctly accounting for timezones/UTC.</p>
+          <form method="post" action="options-general.php?page=simplyrets-admin.php">
+              <input
+                  type="text"
+                  name="sr_lastupdate_offset"
+                  value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
+              />
+              <ul>
+                  <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
+                  <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">relative</a>.</li>
+              </ul>
+              <?php submit_button(); ?>
+          </form>
+        </div>
+        <div>
+          <h3>No search results message</h3>
+          <p>The messasge shown when a search doesn't return results.</p>
+          <form method="post" action="options-general.php?page=simplyrets-admin.php">
+              <textarea
+                  id="sr_custom_no_results_message"
+                  name="sr_custom_no_results_message"
+                  cols="50"
+                  rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
+              <div>
+                  <i>
+                      Default: There are 0 listings that match this
+                      search. Try broadening your search criteria or
+                      try again later.
+                  </i>
+              </div>
+              <?php submit_button(); ?>
+          </form>
+        </div>
+        <?php
   }
 } ?>

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -763,17 +763,16 @@ class SrAdminSettings {
         <div>
           <h3>lastUpdate Manual Offset</h3>
           <p>Useful when data coming through the API isn't correctly accounting for timezones/UTC.</p>
-            <input
-                type="text"
-                name="sr_lastupdate_offset"
-                value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
-            />
-            <ul>
-                <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
-                <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
-            </ul>
-            <?php submit_button(); ?>
-          </form>
+          <input
+              type="text"
+              name="sr_lastupdate_offset"
+              value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
+          />
+          <ul>
+              <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
+              <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
+          </ul>
+          <?php submit_button(); ?>
         </div>
         <hr>
         <div>
@@ -793,6 +792,7 @@ class SrAdminSettings {
           </div>
           <?php submit_button(); ?>
         </div>
+      </form>
     </div>
     <?php
   }

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -732,48 +732,44 @@ class SrAdminSettings {
             </table>
           </div>
           <?php submit_button(); ?>
+          <div>
+            <h3>Custom disclaimer</h3>
+            <p>Custom disclaimer to be shown with all short-codes</p>
+            <textarea
+                id="sr_custom_disclaimer"
+                name="sr_custom_disclaimer"
+                cols="50"
+                rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
+            <ul>
+                <li>
+                    - Use the variable "{lastUpdate}" to interpolate
+                    the time of the last feed update.
+                </li>
+                <li>
+                    - You can use HTML or plain text.
+                </li>
+            </ul>
+          </div>
+          <?php submit_button(); ?>
+          <div>
+            <h3>No search results message</h3>
+            <p>The messasge shown when a search doesn't return results.</p>
+            <textarea
+                id="sr_custom_no_results_message"
+                name="sr_custom_no_results_message"
+                cols="50"
+                rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
+            <div>
+                <i>
+                    Default: There are 0 listings that match this
+                    search. Try broadening your search criteria or
+                    try again later.
+                </i>
+            </div>
+            <?php submit_button(); ?>
+          </div>
         </form>
-        <hr>
-        <div>
-          <h3>Custom disclaimer</h3>
-          <p>Custom disclaimer to be shown with all short-codes</p>
-          <form method="post" action="options-general.php?page=simplyrets-admin.php">
-              <textarea
-                  id="sr_custom_disclaimer"
-                  name="sr_custom_disclaimer"
-                  cols="50"
-                  rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
-              <ul>
-                  <li>
-                      - Use the variable "{lastUpdate}" to interpolate
-                      the time of the last feed update.
-                  </li>
-                  <li>
-                      - You can use HTML or plain text.
-                  </li>
-              </ul>
-              <?php submit_button(); ?>
-          </form>
-        </div>
-        <div>
-          <h3>No search results message</h3>
-          <p>The messasge shown when a search doesn't return results.</p>
-          <form method="post" action="options-general.php?page=simplyrets-admin.php">
-              <textarea
-                  id="sr_custom_no_results_message"
-                  name="sr_custom_no_results_message"
-                  cols="50"
-                  rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
-              <div>
-                  <i>
-                      Default: There are 0 listings that match this
-                      search. Try broadening your search criteria or
-                      try again later.
-                  </i>
-              </div>
-              <?php submit_button(); ?>
-          </form>
-        </div>
-        <?php
+      </div>
+    <?php
   }
 } ?>

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -739,61 +739,60 @@ class SrAdminSettings {
             </table>
           </div>
           <?php submit_button(); ?>
-        </form>
-        <hr>
-        <div>
-          <h3>Custom disclaimer</h3>
-          <p>Custom disclaimer to be shown with all short-codes</p>
-          <textarea
-              id="sr_custom_disclaimer"
-              name="sr_custom_disclaimer"
-              cols="50"
-              rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
-          <ul>
-              <li>
-                  - Use the variable "{lastUpdate}" to interpolate
-                  the time of the last feed update.
-              </li>
-              <li>
-                  - You can use HTML or plain text.
-              </li>
-          </ul>
-        </div>
-        <?php submit_button(); ?>
-        <div>
-          <h3>lastUpdate Manual Offset</h3>
-          <p>Useful when data coming through the API isn't correctly accounting for timezones/UTC.</p>
-          <input
-              type="text"
-              name="sr_lastupdate_offset"
-              value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
-          />
-          <ul>
-              <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
-              <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
-          </ul>
-          <?php submit_button(); ?>
-        </div>
-        <hr>
-        <div>
-          <h3>No search results message</h3>
-          <p>The messasge shown when a search doesn't return results.</p>
-          <textarea
-              id="sr_custom_no_results_message"
-              name="sr_custom_no_results_message"
-              cols="50"
-              rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
+          <hr>
           <div>
-              <i>
-                  Default: There are 0 listings that match this
-                  search. Try broadening your search criteria or
-                  try again later.
-              </i>
+            <h3>Custom disclaimer</h3>
+            <p>Custom disclaimer to be shown with all short-codes</p>
+            <textarea
+                id="sr_custom_disclaimer"
+                name="sr_custom_disclaimer"
+                cols="50"
+                rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
+            <ul>
+                <li>
+                    - Use the variable "{lastUpdate}" to interpolate
+                    the time of the last feed update.
+                </li>
+                <li>
+                    - You can use HTML or plain text.
+                </li>
+            </ul>
           </div>
           <?php submit_button(); ?>
-        </div>
-      </form>
-    </div>
+          <div>
+            <h3>lastUpdate Manual Offset</h3>
+            <p>Useful when data coming through the API isn't correctly accounting for timezones/UTC.</p>
+            <input
+                type="text"
+                name="sr_lastupdate_offset"
+                value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
+            />
+            <ul>
+                <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
+                <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
+            </ul>
+            <?php submit_button(); ?>
+          </div>
+          <hr>
+          <div>
+            <h3>No search results message</h3>
+            <p>The messasge shown when a search doesn't return results.</p>
+            <textarea
+                id="sr_custom_no_results_message"
+                name="sr_custom_no_results_message"
+                cols="50"
+                rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
+            <div>
+                <i>
+                    Default: There are 0 listings that match this
+                    search. Try broadening your search criteria or
+                    try again later.
+                </i>
+            </div>
+            <?php submit_button(); ?>
+          </div>
+        </form>
+      </div>
     <?php
   }
 } ?>

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -744,59 +744,56 @@ class SrAdminSettings {
         <div>
           <h3>Custom disclaimer</h3>
           <p>Custom disclaimer to be shown with all short-codes</p>
-          <form method="post" action="options-general.php?page=simplyrets-admin.php">
-              <textarea
-                  id="sr_custom_disclaimer"
-                  name="sr_custom_disclaimer"
-                  cols="50"
-                  rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
-              <ul>
-                  <li>
-                      - Use the variable "{lastUpdate}" to interpolate
-                      the time of the last feed update.
-                  </li>
-                  <li>
-                      - You can use HTML or plain text.
-                  </li>
-              </ul>
-              <?php submit_button(); ?>
-          </form>
+          <textarea
+              id="sr_custom_disclaimer"
+              name="sr_custom_disclaimer"
+              cols="50"
+              rows="8"><?php echo esc_attr( get_option('sr_custom_disclaimer') ); ?></textarea>
+          <ul>
+              <li>
+                  - Use the variable "{lastUpdate}" to interpolate
+                  the time of the last feed update.
+              </li>
+              <li>
+                  - You can use HTML or plain text.
+              </li>
+          </ul>
         </div>
+        <?php submit_button(); ?>
         <div>
           <h3>lastUpdate Manual Offset</h3>
           <p>Useful when data coming through the API isn't correctly accounting for timezones/UTC.</p>
-          <form method="post" action="options-general.php?page=simplyrets-admin.php">
-              <input
-                  type="text"
-                  name="sr_lastupdate_offset"
-                  value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
-              />
-              <ul>
-                  <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
-                  <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
-              </ul>
-              <?php submit_button(); ?>
+            <input
+                type="text"
+                name="sr_lastupdate_offset"
+                value="<?php echo esc_attr( get_option('sr_lastupdate_offset') ); ?>"
+            />
+            <ul>
+                <li>- Use a valid PHP date or time string (ie. '- 5 hours' or '+ 1 hour')</li>
+                <li>- <a href="https://www.php.net/manual/en/datetime.formats.php" target="_blank">Valid formats</a>: <a href="https://www.php.net/manual/en/datetime.formats.time.php" target="_blank">time</a>, <a href="https://www.php.net/manual/en/datetime.formats.date.php" target="_blank">date</a>, <a href="https://www.php.net/manual/en/datetime.formats.compound.php" target="_blank">compound</a>, and <a href="https://www.php.net/manual/en/datetime.formats.relative.php" target="_blank">relative</a>.</li>
+            </ul>
+            <?php submit_button(); ?>
           </form>
         </div>
+        <hr>
         <div>
           <h3>No search results message</h3>
           <p>The messasge shown when a search doesn't return results.</p>
-          <form method="post" action="options-general.php?page=simplyrets-admin.php">
-              <textarea
-                  id="sr_custom_no_results_message"
-                  name="sr_custom_no_results_message"
-                  cols="50"
-                  rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
-              <div>
-                  <i>
-                      Default: There are 0 listings that match this
-                      search. Try broadening your search criteria or
-                      try again later.
-                  </i>
-              </div>
-              <?php submit_button(); ?>
-          </form>
+          <textarea
+              id="sr_custom_no_results_message"
+              name="sr_custom_no_results_message"
+              cols="50"
+              rows="5"><?php echo esc_attr( get_option('sr_custom_no_results_message') ); ?></textarea>
+          <div>
+              <i>
+                  Default: There are 0 listings that match this
+                  search. Try broadening your search criteria or
+                  try again later.
+              </i>
+          </div>
+          <?php submit_button(); ?>
         </div>
-        <?php
+    </div>
+    <?php
   }
 } ?>

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -124,7 +124,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.9.10 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.9.11 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -245,7 +245,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.9.10 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.9.11 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -781,6 +781,24 @@ HTML;
             $listing_ownership, "Ownership"
         );
 
+        // Compliance/compensation data
+        $complianceData = $listing->compliance;
+        $complianceExtras = "";
+        foreach ($complianceData as $compKey => $compValue) {
+            // Normalize camelCase keys to words
+            $compKey = ucfirst(preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', $compKey));
+            $complianceExtras .= SimplyRetsApiHelper::srDetailsTable($compValue, $compKey);
+        }
+
+        $compensationDisclaimer = "";
+        if (!empty($complianceExtras)) {
+            $compensationDisclaimer .= SimplyRetsApiHelper::srDetailsTable(
+                "The offer of compensation is made only to participants of " .
+                "the MLS where the listing is filed.",
+                "Compensation Disclaimer"
+            );
+        }
+
         $listing_lease_term = $listing->leaseTerm;
         $lease_term = SimplyRetsApiHelper::srDetailsTable($listing_lease_term, "Lease Term");
 
@@ -1296,6 +1314,8 @@ HTML;
                 $officeEmail
                 $agent
                 $agent_phone
+                $complianceExtras
+                $compensationDisclaimer
                 $special_listing_conditions
                 $ownership
                 $terms

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -326,13 +326,21 @@ class SimplyRetsApiHelper {
         $last_update_hdr = 'X-SimplyRETS-LastUpdate';
 
         // Use current timestamp if API doesn't have one
-        if (empty($parsed_headers['X-SimplyRETS-LastUpdate'])) {
+        if (empty($parsed_headers[$last_update_hdr])) {
             return date("M, d Y h:i a");
         }
 
         // Get LastUpdate header value and format the date/time
-        $last_update = $parsed_headers['X-SimplyRETS-LastUpdate'];
+        $last_update = $parsed_headers[$last_update_hdr];
         $hdr = date("M, d Y h:i a", strtotime($last_update));
+
+        if (get_option('sr_lastupdate_offset', false)) {
+          $lastupdated_offset = get_option('sr_lastupdate_offset', false);
+
+          // Add or subtract $lastupdated_offset to $last_update
+          $last_update = date("Y-m-d H:i:s", strtotime($lastupdated_offset, strtotime($last_update)));
+          $hdr = date("M, d Y h:i a", strtotime($last_update));
+        }
 
         return $hdr;
     }

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -562,7 +562,7 @@ class SimplyRetsCustomPostPages {
                 )
             );
 
-            $resource = "/{$listing_id}?{$params}";
+            $resource = "/{$listing_id}?{$params}&include=compliance";
             $content .= SimplyRetsApiHelper::retrieveListingDetails( $resource );
             return $content;
         }

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS
 Plugin URI: https://simplyrets.com
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.9.10
+Version: 2.9.11
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
I got sick of trying to get multiple vendors to wrangle timezones and UTC correctly, so I instead implemented this simple option to manually adjust the '{lastUpdate}' variable using PHP date/time strings. Please feel free to give any tips on code style, tests, etc and I can make the changes.

I whipped this up fairly quickly due to a client's needs, so it probably needs some more eyes on it. May also try to take a look at #212 but other projects are already pulling me away at the moment.