### PR TITLE
Show contact info in "above the fold" compliance markup

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1114,19 +1114,31 @@ HTML;
 
 
         /**
-         * Create the custom compliance markup
+         * Create the custom compliance markup for map marker
          */
         $compliance_markup = SrUtils::mkListingSummaryCompliance($listing_office, $listing_agent_name);
 
 
         /**
-         * Create the "Listing by" markup
+         * Find available contact information to display
+         * Then, create the "Listing by" markup
          */
+        $attribution_contact = property_exists($complianceData, "attributionContact")
+                             ? $complianceData->attributionContact
+                             : NULL;
+        $listing_by_contact = current(array_filter(array(
+            $attribution_contact,
+            $listing_agent_phone,
+            $agent_email,
+            $listing_office_phone,
+            $listing_office_email,
+        )));
+
         $listing_by_markup = SrUtils::mkAgentOfficeAboveTheFold(
             $listing_agent_name,
-            $listing_office
+            $listing_office,
+            $listing_by_contact,
         );
-
 
         $galleria_theme = plugins_url('assets/galleria/themes/classic/galleria.classic.min.js', __FILE__);
 

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -405,10 +405,10 @@ class SrUtils {
      * showing the correct info when only the agent name, or only the
      * office name is available.
      */
-    public static function mkAgentOfficeAboveTheFold($agent, $office) {
-
+    public static function mkAgentOfficeAboveTheFold($agent, $office, $contact = NULL) {
         // Initialize variables
-        $listing_by;
+        $listing_by = "";
+        $listing_by_contact = !empty($contact) ? ", $contact" : "";
 
         // Ensure we have all the info we need
         $agentOfficeAboveTheFoldEnabled = get_option(
@@ -426,6 +426,7 @@ class SrUtils {
                 $listing_by .= "Listing by: ";
                 $listing_by .= "<strong>$agent</strong>, ";
                 $listing_by .= "<strong>$office</strong>";
+                $listing_by .= "<strong>$listing_by_contact</strong>";
                 return "<p>$listing_by</p>";
 
             } elseif (empty($agent) AND !empty($office)) {
@@ -433,7 +434,8 @@ class SrUtils {
                 /**
                  * Only office name is available, show that
                  */
-                $listing_by = "Listing by: <strong>$office</strong>";
+                $listing_by .= "Listing by: <strong>$office</strong>";
+                $listing_by .= "<strong>$listing_by_contact</strong>";
                 return "<p>$listing_by</p>";
 
             } elseif (!empty($agent) AND empty($office)) {
@@ -442,6 +444,7 @@ class SrUtils {
                  * Only agent name is available, show that
                  */
                 $listing_by = "Listing by: <strong>$agent</strong>";
+                $listing_by .= "<strong>$listing_by_contact</strong>";
                 return "<p>$listing_by</p>";
 
             } else {


### PR DESCRIPTION
Where the agent/office attribution is shown "above the fold" on single listing details pages, this adds contact information to that markup.