### PR TITLE
Add grid_view option for [sr_listings] short-code

### DIFF
--- a/src/assets/css/simply-rets-client.css
+++ b/src/assets/css/simply-rets-client.css
@@ -41,6 +41,16 @@ sizes with this class.
     display: block;
 }
 
+.sr-listing-grid-item {
+    width: 32%;
+    display: inline-block;
+    margin: auto;
+    margin-top: 25px;
+    padding: 10px 0 10px 0;
+    vertical-align: top;
+}
+
+
 /*
 Result photo
 ---
@@ -70,6 +80,12 @@ of the image, use this class.
     background-repeat: no-repeat;
 }
 
+.sr-listing-grid-item .sr-photo {
+    height: 200px;
+    width: 100%;
+    display: block;
+    background-size: cover;
+}
 
 /*
 Primary Data
@@ -115,6 +131,11 @@ color is a light grey. This is very simply to change by setting:
     padding-left: 15px;
     margin-top: 10px !important;
     margin-bottom: 10px !important;
+}
+
+.sr-listing-grid-item .sr-listing-data-wrapper {
+    display: block;
+    width: 100%;
 }
 
 /*
@@ -204,6 +225,11 @@ styling:
 
 .sr-listing .result-compliance-markup {
     float: right;
+}
+
+.sr-listing-grid-item .result-compliance-markup {
+    display: block;
+    font-size: 12px;
 }
 
 

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -367,7 +367,7 @@ class SimplyRetsApiHelper {
          */
         foreach( $pag_links as $key=>$link ) {
             $link_parts = parse_url( $link );
-            $no_prefix = array('offset', 'limit', 'type', 'water');
+            $no_prefix = array('offset', 'limit', 'type', 'water', 'grid_view');
 
             $query_part = !empty($link_parts['query']) ? $link_parts['query'] : NULL;
             $output = SrUtils::proper_parse_str($query_part);

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1402,6 +1402,8 @@ HTML;
         $prev_link = $pag['prev'];
         $next_link = $page_count < $limit ? "" : $pag['next'];
 
+        $grid_view = $settings['grid_view'] == TRUE;
+
         /** Allow override of "map_position" admin setting on a per short-code basis */
         $map_setting = isset($settings['show_map']) ? $settings['show_map'] : '';
         $map_position = isset($settings['map_position'])
@@ -1610,45 +1612,86 @@ HTML;
                 "sr-data-column-bathrooms"
             );
 
-            // append markup for this listing to the content
-            $resultsMarkup .= <<<HTML
-              <hr>
-              <div class="sr-listing">
-                <a href="$link">
-                  <div class="sr-photo" style="background-image:url('$main_photo');">
-                  </div>
-                </a>
-                <div class="sr-listing-data-wrapper">
-                  <div class="sr-primary-data">
-                    <a href="$link">
-                      <h4>$full_address
-                        <small class="sr-price"><i> - $listing_USD</i></small>
-                      </h4>
-                    </a>
-                  </div>
-                  <div class="sr-secondary-data">
-                    <ul class="sr-data-column">
-                      $cityMarkup
-                      $yearMarkup
-                      $mlsidMarkup
-                    </ul>
-                    <ul class="sr-data-column">
-                      $bedsMarkup
-                      $bathsMarkup
-                      $areaMarkup
-                    </ul>
-                  </div>
-                </div>
-                <div class="more-details-wrapper">
-                  <span class="more-details-link">
-                      <a href="$link">More details</a>
-                  </span>
-                  <span class="result-compliance-markup">
-                    $compliance_markup
-                  </span>
-                </div>
-              </div>
+            if ($grid_view == true) {
+                // append markup for this listing to the content
+                $resultsMarkup .= <<<HTML
+                    <div class="sr-listing-grid-item">
+                      <a href="$link">
+                        <div class="sr-photo" style="background-image:url('$main_photo');">
+                        </div>
+                      </a>
+                      <div class="sr-listing-data-wrapper">
+                        <div class="sr-primary-data">
+                          <a href="$link">
+                            <h4>$full_address
+                              <small class="sr-price"><i> - $listing_USD</i></small>
+                            </h4>
+                          </a>
+                        </div>
+                        <div class="sr-secondary-data">
+                          <ul class="sr-data-column">
+                            $cityMarkup
+                            $yearMarkup
+                            $mlsidMarkup
+                          </ul>
+                          <ul class="sr-data-column">
+                            $bedsMarkup
+                            $bathsMarkup
+                            $areaMarkup
+                          </ul>
+                        </div>
+                      </div>
+                      <div class="more-details-wrapper">
+                        <span class="more-details-link">
+                            <a href="$link">More details</a>
+                        </span>
+                        <span class="result-compliance-markup">
+                          $compliance_markup
+                        </span>
+                      </div>
+                    </div>
 HTML;
+            } else {
+                // append markup for this listing to the content
+                $resultsMarkup .= <<<HTML
+                    <hr>
+                    <div class="sr-listing">
+                      <a href="$link">
+                        <div class="sr-photo" style="background-image:url('$main_photo');">
+                        </div>
+                      </a>
+                      <div class="sr-listing-data-wrapper">
+                        <div class="sr-primary-data">
+                          <a href="$link">
+                            <h4>$full_address
+                              <small class="sr-price"><i> - $listing_USD</i></small>
+                            </h4>
+                          </a>
+                        </div>
+                        <div class="sr-secondary-data">
+                          <ul class="sr-data-column">
+                            $cityMarkup
+                            $yearMarkup
+                            $mlsidMarkup
+                          </ul>
+                          <ul class="sr-data-column">
+                            $bedsMarkup
+                            $bathsMarkup
+                            $areaMarkup
+                          </ul>
+                        </div>
+                      </div>
+                      <div class="more-details-wrapper">
+                        <span class="more-details-link">
+                            <a href="$link">More details</a>
+                        </span>
+                        <span class="result-compliance-markup">
+                          $compliance_markup
+                        </span>
+                      </div>
+                    </div>
+HTML;
+            }
 
         }
 

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -618,7 +618,8 @@ class SimplyRetsCustomPostPages {
             $idx       = get_query_var( 'sr_idx', '' );
             /** multi mls */
             $vendor    = get_query_var('sr_vendor', '');
-
+            /** Settings */
+            $grid_view = get_query_var("grid_view", FALSE);
             $map_position = get_query_var('sr_map_position',
                                           get_option('sr_search_map_position'));
 
@@ -930,12 +931,14 @@ class SimplyRetsCustomPostPages {
                    SimplyRETS query parameters, but it's the easiest
                    way to get them back on the other side right now.
                 */
+                "grid_view" => $grid_view,
                 "map_position" => $map_position
             );
 
             $settings = array(
-                "limit"     => $limit,
-                "map_position" => $map_position
+                "limit" => $limit,
+                "map_position" => $map_position,
+                "grid_view" => $grid_view
             );
 
             /*

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -208,6 +208,7 @@ class SimplyRetsCustomPostPages {
         $vars[] = "sr_vendor";
         // settings
         $vars[] = "sr_map_position";
+        $vars[] = "grid_view";
         return $vars;
     }
 

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -272,7 +272,12 @@ HTML;
      * ie, [sr_residential mlsid="12345"]
      */
     public static function sr_residential_shortcode($atts = array ()) {
-        $setting_atts = array("map_position" => "map_above", "show_map" => "true");
+        $setting_atts = array(
+            "map_position" => "map_above",
+            "show_map" => "true",
+            "grid_view" => false,
+        );
+
         $data = SrShortcodes::parseShortcodeAttributes($atts, $setting_atts);
 
         // Use /properties/:id if `mlsid` parameter is used

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -340,6 +340,9 @@ HTML;
             $vendor = $availableVendors[0];
         }
 
+        /** Settings */
+        $grid_view = isset($atts["grid_view"]) ? $atts["grid_view"] : FALSE;
+
         /** User Facing Parameters */
         $minbeds    = array_key_exists('minbeds',  $atts) ? $atts['minbeds']  : '';
         $maxbeds    = array_key_exists('maxbeds',  $atts) ? $atts['maxbeds']  : '';
@@ -583,6 +586,7 @@ HTML;
                 <input type="hidden" name="sr_areaMinor" value="<?php echo $areaMinor; ?>" />
                 <input type="hidden" name="sr_ownership" value="<?php echo $ownership; ?>" />
                 <input type="hidden" name="sr_salesagent" value="<?php echo $salesAgent; ?>" />
+                <input type="hidden" name="grid_view" value="<?php echo $grid_view; ?>" />
 
                 <div>
                     <button class="btn button submit btn-submit" style="display:inline-block;">Search</button>
@@ -679,6 +683,7 @@ HTML;
             <input type="hidden" name="sr_state" value="<?php echo $state; ?>" />
             <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
             <input type="hidden" name="status"     value="<?php echo $adv_status; ?>" />
+            <input type="hidden" name="grid_view" value="<?php echo $grid_view; ?>" />
             <input
                 type="hidden"
                 name="sr_specialListingConditions"


### PR DESCRIPTION
Fixes #86 

This adds support for a `grid_view` option that can be used on the [sr_listings] short-code. When this is enabled, the listings from this short-code will show multiple (3) on a row instead of one per row.