### PR TITLE
Add default value for srResidentialResultsGenerator argument

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1367,7 +1367,7 @@ HTML;
     }
 
 
-    public static function srResidentialResultsGenerator($request_response, $settings, $params) {
+    public static function srResidentialResultsGenerator($request_response, $settings, $params = array()) {
         $cont              = "";
         $pagination        = $request_response['pagination'];
         $lastUpdate        = $request_response['lastUpdate'];


### PR DESCRIPTION
Fix error in `[sr_map_search]` short-code when fetching listings