### PR TITLE
Add getHeader for case-insensitive API response header lookup

### DIFF
--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -288,6 +288,21 @@ class SrUtils {
     }
 
     /**
+     * Lookup header value from array.
+     * This helper function ensures a case insensitive lookup.
+     */
+    public static function getHeader($headers, $header_name) {
+        $header_name = strtolower($header_name);
+        $header_list = array_change_key_case($headers, CASE_LOWER);
+
+        if (array_key_exists($header_name, $header_list)) {
+            return $header_list[$header_name];
+        } else {
+            return NULL;
+        }
+    }
+
+    /**
      * Build a query string from an array of parameters. NOTE: This
      * function REMOVES array indexes ([0]) from parameters names that
      * are specified multiple times. For example:


### PR DESCRIPTION
In HTTP/2 HTTP headers are transformed to lower-case. Currently our code relies on an exact match with capital letters.

This adds a `getHeader` function to get an HTTP header from an array case-insensitively.