### PR TITLE
Fix warning when hiding listing remarks

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -962,9 +962,8 @@ HTML;
         }
 
         if( get_option('sr_show_listing_remarks') ) {
-            $show_remarks = false;
+            $remarks_markup = "";
         } else {
-            $show_remarks = true;
             $remarks = $listing->remarks;
             $remarks_markup = <<<HTML
             <div class="sr-remarks-details">


### PR DESCRIPTION
Fixes warning for:

```
Warning: Undefined variable $remarks_markup
```

that occurs when the admin option to _hide_ listing remarks is enabled.