### PR TITLE
Prefer list agent "cell" field over "office" field

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1036,7 +1036,11 @@ HTML;
 
         $agent = SimplyRetsApiHelper::srDetailsTable($listing_agent_name, "Listing Agent");
 
-        $listing_agent_phone = $has_agent_contact_info ? $listing->agent->contact->office : '';
+        $listing_agent_cell_phone = $has_agent_contact_info ? $listing->agent->contact->cell : '';
+        $listing_agent_office_phone = $has_agent_contact_info ? $listing->agent->contact->office: '';
+        $listing_agent_phone = $listing_agent_cell_phone
+                             ? $listing_agent_cell_phone
+                             : $listing_agent_office_phone;
         $agent_phone = SimplyRetsApiHelper::srDetailsTable($listing_agent_phone, "Listing Agent Phone");
 
 


### PR DESCRIPTION
With recent fixes in the upstream API, this makes sure that the agent.contact.cell (ListAgentPreferredPhone) field takes priority over agent.contact.offce (ListOfficePhone).