### PR TITLE
Improve address display when city, state, or zip don't exist

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.10.6
+* FIX: Remove commas in address when city, state, or zip doesn't exist
+* UPDATE: Update link to demo and documentation site
+
 ## 2.10.5
 * FIX: Prefer list agent "cell" field over "office" field
 * FIX: Fix warning when listing remarks doesn't exist

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: idx, rets, reso web api, mls, idx plugin, mls listings, reso, real estate, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 6.4.3
-Stable tag: 2.10.5
+Stable tag: 2.10.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -236,6 +236,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.10.6 =
+* FIX: Remove commas in address when city, state, or zip doesn't exist
+* UPDATE: Update link to demo and documentation site
 
 = 2.10.5 =
 * FIX: Prefer list agent "cell" field over "office" field

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -149,11 +149,8 @@ class SrAdminSettings {
             <a target="_blank" href="http://simplyrets.com">
                 simplyrets.com
             </a> |
-            <a target="_blank" href="https://wordpress.org/plugins/simply-rets/other_notes/">
-                Plugin Docs
-            </a> |
-            <a target="_blank" href="http://docs.simplyrets.com">
-                API Docs
+            <a target="_blank" href="https://wordpress-demo.simplyrets.com/">
+                Plugin demo and documentation
             </a> |
             <a target="_blank" href="http://status.simplyrets.com">
                 Service Status
@@ -199,7 +196,7 @@ class SrAdminSettings {
               </tbody>
             </table>
           </div>
-          <div>
+          <div style="margin-top: 15px;">
             <span>
               <i>Note - to use the SimplyRETS demo data, you can use these  API credentials: </i>
               <strong>API Key: </strong><span>simplyrets</span>

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -124,7 +124,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.10.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.10.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -235,7 +235,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.10.5 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.10.6 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -121,12 +121,13 @@ class SrUtils {
         $state = $listing->address->state;
         $zip = $listing->address->postalCode;
 
-        // A listing might have a null address if a flag like "Display
-        // address" is set to false. This just removes the comma in
-        // these cases, but the rest of the address remains the same.
-        $comma = $address ? ', ' : '';
+        // When `internetAddressDisplay` is false, some feeds may also
+        // exclude city, state, and zip. This ensures that commas are
+        // only used when these fields exist.
+        $comma1 = ($address AND ($city OR $state OR $zip)) ? ', ' : '';
+        $comma2 = $city ? ', ' : '';
 
-        return $address . $comma . $city . ', ' . $state . ' ' . $zip;
+        return $address . $comma1 . $city . $comma2 . $state . ' ' . $zip;
     }
 
     /**

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS Real Estate IDX
 Plugin URI: https://simplyrets.com/wordpress-idx-plugin
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.10.5
+Version: 2.10.6
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
When `internetAddressDisplay` is set to false, some feeds do not provide the city, state, or zip code as well. This prevents extra commas from being displayed when this address information is null.

**With city, state, zip**
![image](https://github.com/SimplyRETS/simplyretswp/assets/7034627/46778d75-6105-4900-b1d5-28ed23280e70)

**Without city, state, zip**
![image](https://github.com/SimplyRETS/simplyretswp/assets/7034627/c0873ba0-7d76-4f0d-80d1-82fc2d29da86)
