### PR TITLE
Show listing status in results view

### DIFF
--- a/src/assets/css/simply-rets-client.css
+++ b/src/assets/css/simply-rets-client.css
@@ -75,7 +75,7 @@ of the image, use this class.
     height: 155px;
     width: 30%;
     overflow: hidden;
-    background-size: contain;
+    background-size: cover;
     background-position: center center;
     background-repeat: no-repeat;
 }
@@ -85,6 +85,28 @@ of the image, use this class.
     width: 100%;
     display: block;
     background-size: cover;
+}
+
+.sr-listing-status {
+    padding: 10px;
+    color: white;
+    font-weight: 700;
+    background-color: rgba(128, 128, 128, 0.75);
+}
+
+.sr-listing-status-active,
+.sr-listing-status-comingsoon {
+    background-color: rgba(0, 128, 0, 0.75);
+}
+
+.sr-listing-status-activeundercontract,
+.sr-listing-status-pending {
+    background-color: rgba(255, 165, 0, 0.75);
+}
+
+.sr-listing > a:first-child,
+.sr-listing-grid-item > a:first-child {
+    text-decoration: none !important;
 }
 
 /*

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -1462,6 +1462,7 @@ HTML;
              */
             $mls_status = SrListing::listingStatus($listing);
             $full_address = SrUtils::buildFullAddressString($listing);
+            $status_class = SrListing::listingStatusClass($listing->mls->status);
 
             $listing_USD = $listing_price == "" ? "" : '$' . number_format( $listing_price );
 
@@ -1609,9 +1610,14 @@ HTML;
             if ($grid_view == true) {
                 // append markup for this listing to the content
                 $resultsMarkup .= <<<HTML
-                    <div class="sr-listing-grid-item">
+                    <div class="sr-listing-grid-item" id="{$status_class}">
                       <a href="$link">
                         <div class="sr-photo" style="background-image:url('$main_photo');">
+                            <span class="sr-listing-status {$status_class}">
+                                <span class="sr-listing-status-text">
+                                    $mls_status
+                                </span>
+                            </span>
                         </div>
                       </a>
                       <div class="sr-listing-data-wrapper">
@@ -1649,9 +1655,14 @@ HTML;
                 // append markup for this listing to the content
                 $resultsMarkup .= <<<HTML
                     <hr>
-                    <div class="sr-listing">
+                    <div class="sr-listing" id="{$status_class}">
                       <a href="$link">
                         <div class="sr-photo" style="background-image:url('$main_photo');">
+                            <span class="sr-listing-status {$status_class}">
+                                <span class="sr-listing-status-text">
+                                    $mls_status
+                                </span>
+                            </span>
                         </div>
                       </a>
                       <div class="sr-listing-data-wrapper">

--- a/src/simply-rets-utils.php
+++ b/src/simply-rets-utils.php
@@ -526,6 +526,15 @@ class SrListing {
     }
 
     /**
+     * Create a CSS class name for a standard status
+     */
+    public static function listingStatusClass($status) {
+        $status = strtolower($status);
+
+        return "sr-listing-status-{$status}";
+    }
+
+    /**
      * Return a 'display-ready' number of bathrooms for a
      * listing. Checks for `.property.bathrooms` first, and then
      * `.property.bathsFull`, and pluralizes the "bath(s)" text.


### PR DESCRIPTION
Add a banner to the listings in the results view that show the listing status. Additionally, have a CSS class with the listing status so that users can target this element with custom CSS for a given status.

- [x] Add listing status banner
- [x] Add CSS class for listing status
- [x] Add top level `id` with listing status so users can target with custom styles