### PR TITLE
Fix option filters not working in pagination

### DIFF
--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -15,7 +15,7 @@ class SimplyRetsApiHelper {
     public static function retrieveRetsListings( $params, $settings = NULL ) {
         $request_url      = SimplyRetsApiHelper::srRequestUrlBuilder( $params );
         $request_response = SimplyRetsApiHelper::srApiRequest( $request_url );
-        $response_markup  = SimplyRetsApiHelper::srResidentialResultsGenerator($request_response, $settings, $params);
+        $response_markup  = SimplyRetsApiHelper::srResidentialResultsGenerator($request_response, $settings);
 
         return $response_markup;
     }
@@ -356,7 +356,7 @@ class SimplyRetsApiHelper {
          */
         foreach( $pag_links as $key=>$link ) {
             $link_parts = parse_url( $link );
-            $no_prefix = array('offset', 'limit', 'type', 'water', 'grid_view');
+            $no_prefix = array('offset', 'limit', 'type', 'water', 'grid_view', "show_map");
 
             $query_part = !empty($link_parts['query']) ? $link_parts['query'] : NULL;
             $output = SrUtils::proper_parse_str($query_part);
@@ -1371,7 +1371,7 @@ HTML;
     }
 
 
-    public static function srResidentialResultsGenerator($request_response, $settings, $params = array()) {
+    public static function srResidentialResultsGenerator($request_response, $settings) {
         $cont              = "";
         $pagination        = $request_response['pagination'];
         $lastUpdate        = $request_response['lastUpdate'];
@@ -1391,7 +1391,7 @@ HTML;
 
         /** Build pagination links HTML **/
         $page_count = count($response);
-        $limit = isset($params['limit']) ? $params['limit'] : 20;
+        $limit = isset($settings['limit']) ? $settings['limit'] : 20;
         $pag = SrUtils::buildPaginationLinks( $pagination );
         $prev_link = $pag['prev'];
         $next_link = $page_count < $limit ? "" : $pag['next'];

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -208,6 +208,7 @@ class SimplyRetsCustomPostPages {
         $vars[] = "sr_vendor";
         // settings
         $vars[] = "sr_map_position";
+        $vars[] = "show_map";
         $vars[] = "grid_view";
         return $vars;
     }
@@ -619,7 +620,8 @@ class SimplyRetsCustomPostPages {
             /** multi mls */
             $vendor    = get_query_var('sr_vendor', '');
             /** Settings */
-            $grid_view = get_query_var("grid_view", FALSE);
+            $grid_view = get_query_var("grid_view", false);
+            $show_map = get_query_var("show_map", true);
             $map_position = get_query_var('sr_map_position',
                                           get_option('sr_search_map_position'));
 
@@ -932,12 +934,14 @@ class SimplyRetsCustomPostPages {
                    way to get them back on the other side right now.
                 */
                 "grid_view" => $grid_view,
+                "show_map" => $show_map,
                 "map_position" => $map_position
             );
 
             $settings = array(
                 "limit" => $limit,
                 "map_position" => $map_position,
+                "show_map" => $show_map,
                 "grid_view" => $grid_view
             );
 

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -241,7 +241,6 @@ HTML;
             // Parse settings, don't add them to the API query
             if (array_key_exists($param, $setting_atts)) {
                 $attributes["settings"][$param] = $value;
-                continue;
             }
 
             $values = explode(";", $value);
@@ -250,11 +249,6 @@ HTML;
             }
 
             $attributes["params"][$name] = count($values) > 1 ? $values : $value;
-
-            // Add vendor to params and settings
-            if ($param === "vendor") {
-                $attributes["settings"]["vendor"] = $value;
-            }
         }
 
         return $attributes;
@@ -282,6 +276,8 @@ HTML;
             "map_position" => get_option('sr_search_map_position', 'map_above'),
             "show_map" => "true",
             "grid_view" => false,
+            "vendor" => "",
+            "limit" => 20
         );
 
         $data = SrShortcodes::parseShortcodeAttributes($atts, $setting_atts);
@@ -348,6 +344,7 @@ HTML;
 
         /** Settings */
         $grid_view = isset($atts["grid_view"]) ? $atts["grid_view"] : FALSE;
+        $show_map = isset($atts["show_map"]) ? $atts["show_map"] : TRUE;
 
         /** User Facing Parameters */
         $minbeds    = array_key_exists('minbeds',  $atts) ? $atts['minbeds']  : '';
@@ -593,6 +590,7 @@ HTML;
                 <input type="hidden" name="sr_ownership" value="<?php echo $ownership; ?>" />
                 <input type="hidden" name="sr_salesagent" value="<?php echo $salesAgent; ?>" />
                 <input type="hidden" name="grid_view" value="<?php echo $grid_view; ?>" />
+                <input type="hidden" name="show_map" value="<?php echo $show_map; ?>" />
 
                 <div>
                     <button class="btn button submit btn-submit" style="display:inline-block;">Search</button>
@@ -690,6 +688,7 @@ HTML;
             <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
             <input type="hidden" name="status"     value="<?php echo $adv_status; ?>" />
             <input type="hidden" name="grid_view" value="<?php echo $grid_view; ?>" />
+            <input type="hidden" name="show_map" value="<?php echo $show_map; ?>" />
             <input
                 type="hidden"
                 name="sr_specialListingConditions"


### PR DESCRIPTION
This fixes an issue where some option filters like `map_position` and `grid_view` are dropped when using the pagination links.