### PR TITLE
Add support for Block Theme templates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.11.2
+* FEATURE: Add support for Block Theme templates
+* FEATURE: Add support for lotDescription filter
+* IMPROVE: Use consistent h3 in basic and advanced search form
+* IMPROVE: Normalize CamelCase property types in search form dropdown
+
 ## 2.11.1
 * ADD: Add CloseDate to closed listing thumbnails
 * IMPROVE: Improve CSS selectors for listing thumbnail status banner

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,8 +3,8 @@ Author: SimplyRETS
 Contributors: SimplyRETS
 Tags: idx, rets, reso web api, mls, idx plugin, mls listings, reso, real estate, realtor, rets feed, idx feed
 Requires at least: 3.0.1
-Tested up to: 6.4.3
-Stable tag: 2.11.1
+Tested up to: 6.6.1
+Stable tag: 2.11.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -236,6 +236,12 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 2.11.2 =
+* FEATURE: Add support for Block Theme templates
+* FEATURE: Add support for lotDescription filter
+* IMPROVE: Use consistent h3 in basic and advanced search form
+* IMPROVE: Normalize CamelCase property types in search form dropdown
 
 = 2.11.1 =
 * ADD: Add CloseDate to closed listing thumbnails

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -534,7 +534,7 @@ HTML;
 
                     $markup .= "<img src='$image_url' "
                             . "data-title='$full_address'"
-                            . "data-description='$img_description'>";
+                            . "data-description='" . htmlentities($img_description) . "'>";
                 }
 
                 $markup .= "</div>";

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -124,7 +124,7 @@ class SimplyRetsApiHelper {
         $php_version = phpversion();
         $site_url = get_site_url();
 
-        $ua_string     = "SimplyRETSWP/2.11.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.11.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {
@@ -235,7 +235,7 @@ class SimplyRetsApiHelper {
         $wp_version = get_bloginfo('version');
         $php_version = phpversion();
 
-        $ua_string     = "SimplyRETSWP/2.11.1 Wordpress/{$wp_version} PHP/{$php_version}";
+        $ua_string     = "SimplyRETSWP/2.11.2 Wordpress/{$wp_version} PHP/{$php_version}";
         $accept_header = "Accept: application/json; q=0.2, application/vnd.simplyrets-v0.1+json";
 
         if( is_callable( 'curl_init' ) ) {

--- a/src/simply-rets-post-pages.php
+++ b/src/simply-rets-post-pages.php
@@ -155,7 +155,8 @@ class SimplyRetsCustomPostPages {
             'hierarchical'    => true,
             'taxonomies'      => array(),
             'supports'        => array( 'title', 'editor', 'thumbnail', 'page-attributes' ),
-            'rewrite'         => true
+            'rewrite'         => true,
+            'show_in_rest'    => true,
         );
         register_post_type( 'sr-listings', $args );
     }
@@ -496,6 +497,16 @@ class SimplyRetsCustomPostPages {
     public static function srLoadPostTemplate($single) {
         $query_object = get_queried_object();
         $sr_post_type = 'sr-listings';
+
+        /**
+        * If current theme is a Block Theme, return original arg. The
+        * 'Single' block template will be used by default, or the user
+        * can create a custom template for 'Single: SimplyRETS Page'
+        * in the Block Theme Editor settings.
+        */
+        if(function_exists("wp_is_block_theme") && wp_is_block_theme()) {
+            return $single;
+        }
 
         // If this isn't a SimplyRETS page, return default template
         if ($query_object->post_type !== $sr_post_type) {

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS Real Estate IDX
 Plugin URI: https://simplyrets.com/wordpress-idx-plugin
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 2.11.1
+Version: 2.11.2
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2015


### PR DESCRIPTION
Support Block Theme templates, like Twenty-Twenty-Three.

- [x] Don't run `single_template` filter when a block theme is enabled. A block theme will correctly choose the "single" page template for sr-listings pages. 
- [x] Add `show_in_rest` to custom post type settings. This allows the user to create their own template for sr-listings pages. This is the equivalent of using `single-sr-listings.php` in classic themes.