### PR TITLE
Fix [sr_map_search] shortcode not supressing restricted addresses

### DIFF
--- a/src/assets/js/simply-rets-client.js
+++ b/src/assets/js/simply-rets-client.js
@@ -217,7 +217,7 @@ var makeMapMarkers = function(
         var lat = listing.geo.lat,
             lng = listing.geo.lng;
 
-        if(lat && lng) {
+        if(lat && lng && listing.internetAddressDisplay) {
 
             var bound  = new google.maps.LatLng(listing.geo.lat, listing.geo.lng);
 


### PR DESCRIPTION
Fix for the `[sr_map_search]` shortcode not supressing IDX restricted address.

[Download new plugin version here](https://github.com/user-attachments/files/18104516/simplyretswp-dev.zip)

Steps to install:
- Download zip file
- Deactivate and delete the SimplyRETS IDX plugin you currently have installed (don't worry, all your settings will persist!)
- Go to Plugins->Add New Plugin, then _Upload Plugin_ and upload the attached zip file
- Activate after successful installation 