### PR TITLE
Fix areaMinor filter in search_form shortcode

### DIFF
--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -337,7 +337,7 @@ class SrShortcodes {
         $subtype = isset($attributes['subtype']) ? $attributes['subtype'] : '';
         $subTypeText = isset($attributes['subtypetext']) ? $attributes['subtypetext'] : '';
         $counties = isset($attributes['counties']) ? $attributes['counties'] : '';
-        $postalCodes = isset($attributes['postalcodes']) ? $attributes['postalcodes'] : '';
+        $postalCodes = isset($attributes['postalCodes']) ? $attributes['postalCodes'] : '';
         $neighborhoods = isset($attributes['neighborhoods']) ? $attributes['neighborhoods'] : '';
         $cities = isset($attributes['cities']) ? $attributes['cities'] : '';
         $state = isset($attributes['state']) ? $attributes['state'] : '';

--- a/src/simply-rets-shortcode.php
+++ b/src/simply-rets-shortcode.php
@@ -342,9 +342,9 @@ class SrShortcodes {
         $cities = isset($attributes['cities']) ? $attributes['cities'] : '';
         $state = isset($attributes['state']) ? $attributes['state'] : '';
         $specialListingConditions = isset($attributes['speciallistingconditions']) ? $attributes['speciallistingconditions'] : '';
-        $areaMinor = isset($attributes['areaminor']) ? $attributes['areaminor'] : '';
         $ownership = isset($attributes['ownership']) ? $attributes['ownership'] : '';
         $salesAgent = isset($attributes['salesagent']) ? $attributes['salesagent'] : '';
+        $areaMinor = isset($attributes['areaMinor']) ? $attributes['areaMinor'] : '';
         $exteriorFeatures = isset($attributes['exteriorFeatures']) ? $attributes['exteriorFeatures'] : '';
         $lotDescription = isset($attributes['lotDescription']) ? $attributes['lotDescription'] : '';
 


### PR DESCRIPTION
Provides a fix the the `[sr_search_form]` shortcode not using the `areaMinor` filter in some cases.