### PR TITLE
Add sanitization callbacks to register_setting function calls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.4
+
+* FIX: Fix invalid phpcs alert due to period in suppression comment
+* FIX: Fix areaMinor and postalCodes params on paginated results pages
+
 ## 3.0.3
 
 * FIX: Use correct permalink structure in [sr_map_search] map markers

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: idx, rets, reso web api, mls, idx plugin, mls listings, reso, real estate, realtor, rets feed, idx feed
 Requires at least: 3.0.1
 Tested up to: 6.8
-Stable tag: 3.0.3
+Stable tag: 3.0.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -236,6 +236,11 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 3.0.4 =
+
+* FIX: Fix invalid phpcs alert due to period in suppression comment
+* FIX: Fix areaMinor and postalCodes params on paginated results pages
 
 = 3.0.3 =
 

--- a/src/simply-rets-admin.php
+++ b/src/simply-rets-admin.php
@@ -24,39 +24,48 @@ class SrAdminSettings {
   }
 
   public static function register_admin_settings() {
-      register_setting('sr_admin_settings', 'sr_api_name');
-      register_setting('sr_admin_settings', 'sr_api_key');
-      register_setting('sr_admin_settings', 'sr_contact_page');
-      register_setting('sr_admin_settings', 'sr_show_listingmeta');
-      register_setting('sr_admin_settings', 'sr_show_listing_remarks');
-      register_setting('sr_admin_settings', 'sr_show_agent_contact');
-      register_setting('sr_admin_settings', 'sr_listing_gallery');
-      register_setting('sr_admin_settings', 'sr_show_leadcapture');
-      register_setting('sr_admin_settings', 'sr_leadcapture_recipient');
-      register_setting('sr_admin_settings', 'sr_additional_rooms');
-      register_setting('sr_admin_settings', 'sr_listhub_analytics');
-      register_setting('sr_admin_settings', 'sr_listhub_analytics_id');
-      register_setting('sr_admin_settings', 'sr_listhub_analytics_test_events');
-      register_setting('sr_admin_settings', 'sr_search_map_position');
-      register_setting('sr_admin_settings', 'sr_permalink_structure');
-      register_setting('sr_admin_settings', 'sr_google_api_key');
-      register_setting('sr_admin_settings', 'sr_office_on_thumbnails');
-      register_setting('sr_admin_settings', 'sr_agent_on_thumbnails');
-      register_setting('sr_admin_settings', 'sr_thumbnail_idx_image');
-      register_setting('sr_admin_settings', 'sr_custom_disclaimer');
-      register_setting('sr_admin_settings', 'sr_custom_no_results_message');
-      register_setting('sr_admin_settings', 'sr_show_mls_status_text');
-      register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold');
-      register_setting('sr_admin_settings', 'sr_show_mls_trademark_symbol');
-      register_setting('sr_admin_settings', 'sr_disable_listing_details_map');
+      $def_setting_opts = array(
+          "sanitize_callback" => "sanitize_text_field"
+      );
+
+      register_setting('sr_admin_settings', 'sr_api_name', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_api_key', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_contact_page', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_show_listingmeta', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_show_listing_remarks', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_show_agent_contact', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_listing_gallery', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_show_leadcapture', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_leadcapture_recipient', array(
+          "sanitize_callback" => "sanitize_email"
+      ));
+      register_setting('sr_admin_settings', 'sr_additional_rooms', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_listhub_analytics', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_listhub_analytics_id', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_listhub_analytics_test_events', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_search_map_position', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_permalink_structure', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_google_api_key', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_office_on_thumbnails', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_agent_on_thumbnails', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_thumbnail_idx_image', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_custom_disclaimer', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_custom_no_results_message', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_show_mls_status_text', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_agent_office_above_the_fold', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_show_mls_trademark_symbol', $def_setting_opts);
+      register_setting('sr_admin_settings', 'sr_disable_listing_details_map', $def_setting_opts);
       register_setting('sr_admin_settings', 'sr_default_idx_filter', array(
-          "default" => "null"
+          "default" => "null",
+          "sanitize_callback" => "sanitize_text_field"
       ));
       register_setting('sr_admin_settings', 'sr_idx_address_display_text', array(
-          "default" => "Undisclosed address"
+          "default" => "Undisclosed address",
+          "sanitize_callback" => "sanitize_text_field"
       ));
       register_setting('sr_admin_settings', 'sr_date_default_timezone', array(
-          "default" => ""
+          "default" => "",
+          "sanitize_callback" => "sanitize_text_field"
       ));
       register_setting('sr_admin_settings', 'sr_listing_force_image_https', array(
           "default" => false

--- a/src/simply-rets-api-helper.php
+++ b/src/simply-rets-api-helper.php
@@ -677,7 +677,7 @@ class SimplyRetsApiHelper {
         $listing_subType = $listing->property->subType;
         $subType = SimplyRetsApiHelper::srDetailsTable($listing_subType, "Sub type");
         $listing_subTypeText = $listing->property->subTypeText;
-        $subTypeText = SimplyRetsApiHelper::srDetailsTable($listing_subTypeText, "MLS Sub type");
+        $subTypeText = SimplyRetsApiHelper::srDetailsTable($listing_subTypeText, $MLS_text . " Sub type");
         // bedrooms
         $listing_bedrooms = $listing->property->bedrooms;
         $bedrooms = SimplyRetsApiHelper::srDetailsTable($listing_bedrooms, "Bedrooms");

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS Real Estate IDX
 Plugin URI: https://simplyrets.com/wordpress-idx-plugin
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 3.0.3
+Version: 3.0.4
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2024
@@ -12,7 +12,7 @@ Copyright (c) SimplyRETS 2014 - 2024
 */
 
 /* Code starts here */
-const SIMPLYRETSWP_VERSION = "v3.0.3";
+const SIMPLYRETSWP_VERSION = "v3.0.4";
 
 $plugin = plugin_basename(__FILE__);
 $php_version = phpversion();


### PR DESCRIPTION
= 3.0.4 =

- Fix invalid security scan alerts
- Fix `areaMinor` and `postalCodes` parameters not being retained when paginating


## Install from zip file
1. Download .zip file: [simplyretswp-dev.zip](https://github.com/user-attachments/files/20373758/simplyretswp-dev.zip)
2. Go to Plugins -> Add New -> Upload Plugin in your WordPress dashboard
3. Upload the file, it should prompt you to deactivate existing plugin and activate the uploaded plugin.
  - Confirm this action and then test the site
  - If it fails due to an existing plugin, deactivate your current SimplyRETS plugin (no need to fully delete) and then upload the zip file.

